### PR TITLE
Change payments to be full table stream since you can only query on created time but records can be updated

### DIFF
--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -114,10 +114,10 @@ class Refunds():
 class Payments():
     tap_stream_id = 'payments'
     key_properties = ['id']
-    replication_method = 'INCREMENTAL'
-    valid_replication_keys = ['updated_at']
-    replication_key = 'updated_at'
-    object_type = 'DISCOUNT'
+    replication_method = 'FULL_TABLE'
+    valid_replication_keys = []
+    replication_key = None
+    object_type = 'PAYMENT'
 
     def sync(self, client, start_time, bookmarked_cursor): #pylint: disable=no-self-use
         for page, cursor in client.get_payments(start_time, bookmarked_cursor):

--- a/tests/base.py
+++ b/tests/base.py
@@ -138,8 +138,7 @@ class TestSquareBase(unittest.TestCase):
             },
             "payments": {
                 self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'updated_at'}
+                self.REPLICATION_METHOD: self.FULL,
             },
             "modifier_lists": {
                 self.PRIMARY_KEYS: {'id'},

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -19,7 +19,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
         return self.dynamic_data_streams().difference(
             {  # STREAMS NOT CURRENTY TESTABLE
                 'employees', # Requires production environment to create records
-                'payments', # BUG https://stitchdata.atlassian.net/browse/SRCE-3579
                 'modifier_lists',
                 'inventories',
             }

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -33,7 +33,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
     def streams_with_record_differences_after_create(self):
         return {
-            'refunds',  # TODO: File bug with square about visible difference - provide recreatable scenario 
+            'refunds',  # TODO: File bug with square about visible difference - provide recreatable scenario
         }
 
     @classmethod
@@ -200,9 +200,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
                     self.assertEqual(len(expected_records_2.get(stream)), 2,
                                      msg="Expectations are invalid for incremental stream {}".format(stream))
             if stream in self.expected_full_table_streams():
-                if len(expected_records_2.get(stream)) != len(expected_records_1.get(stream)) + len(created_records[stream]):
-                    import ipdb; ipdb.set_trace()
-                    1+1
                 self.assertEqual(len(expected_records_2.get(stream)), len(expected_records_1.get(stream)) + len(created_records[stream]),
                                  msg="Expectations are invalid for full table stream {}".format(stream))
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -146,16 +146,15 @@ class TestSquareIncrementalReplication(TestSquareBase):
                 refund = created_records[stream][0]
                 payment_id = refund.get('payment_id')
                 updated_records['payments'] += self.client.get_a_payment(payment_id)
-                # a CREATE for refunds could also result in a new payments object
-                if len(self.client.PAYMENTS) > len(created_records['payments']) + len(expected_records_1['payments']):
-                    created_records['payments'].append(self.client.PAYMENTS[-1])
-                    expected_records_2['payments'].append(self.client.PAYMENTS[-1])
+                # a CREATE for refunds will result in a new payments object
+                created_records['payments'].append(self.client.PAYMENTS[-1])
+                expected_records_2['payments'].append(self.client.PAYMENTS[-1])
 
         for stream in self.testable_streams().difference(self.cannot_update_streams()):
             # Update
 
             if stream == 'payments':
-                # Payments which have already completed/cancelled can't be done so again so much find first APPROVED payment
+                # Payments which have already completed/cancelled can't be done so again so find first APPROVED payment
                 first_rec = dict()
                 for message in first_sync_records.get(stream).get('messages'):
                     if message.get('data')['status'] == 'APPROVED':
@@ -200,6 +199,9 @@ class TestSquareIncrementalReplication(TestSquareBase):
                     self.assertEqual(len(expected_records_2.get(stream)), 2,
                                      msg="Expectations are invalid for incremental stream {}".format(stream))
             if stream in self.expected_full_table_streams():
+                if len(expected_records_2.get(stream)) != len(expected_records_1.get(stream)) + len(created_records[stream]):
+                    import ipdb; ipdb.set_trace()
+                    1+1
                 self.assertEqual(len(expected_records_2.get(stream)), len(expected_records_1.get(stream)) + len(created_records[stream]),
                                  msg="Expectations are invalid for full table stream {}".format(stream))
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -145,7 +145,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
             if stream == 'refunds':  # a CREATE for refunds is equivalent to an UPDATE for payments
                 refund = created_records[stream][0]
                 payment_id = refund.get('payment_id')
-                updated_records['payments'] += self.client.get_a_payment(payment_id)
                 # a CREATE for refunds will result in a new payments object
                 created_records['payments'].append(self.client.PAYMENTS[-1])
                 expected_records_2['payments'].append(self.client.PAYMENTS[-1])
@@ -170,6 +169,8 @@ class TestSquareIncrementalReplication(TestSquareBase):
             updated_record = self.client.update(stream, first_rec_id, first_rec_version)
             assert len(updated_record) > 0, "Failed to update a {} record".format(stream)
             assert len(updated_record) == 1, "Updated too many {} records".format(stream)
+            if stream == 'payments':
+                updated_record = self.client.get_a_payment(first_rec_id, self.START_DATE)
             expected_records_2[stream] += updated_record
             updated_records[stream] += updated_record
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -75,8 +75,8 @@ class TestClient(SquareClient):
         elif stream == 'refunds':
             return [obj for page, _ in self.get_refunds(start_date, None) for obj in page]
         elif stream == 'payments':
-            if not self.PAYMENTS:
-                self.PAYMENTS = [obj for page, _ in self.get_payments(start_date, None) for obj in page]
+            #if not self.PAYMENTS:
+            self.PAYMENTS = [obj for page, _ in self.get_payments(start_date, None) for obj in page]
             return self.PAYMENTS
         elif stream == 'modifier_lists':
             return [obj for page, _ in self.get_catalog('MODIFIER_LIST', start_date, None) for obj in page]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,7 +203,7 @@ class TestClient(SquareClient):
                 if refund.is_error(): # Debugging
                     print("body: {}".format(body))
                     print("response: {}".format(refund))
-                    print("payment attempted to be refunded: {}", payment_obj)
+                    print("payment attempted to be refunded: {}".format(payment))
                     raise RuntimeError(refund.errors)
             else:
                 raise RuntimeError(refund.errors)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -96,7 +96,7 @@ class TestClient(SquareClient):
 
             return_value = None if len(return_value) > 0 and return_value[0].get('status') == 'APPROVED' else return_value
 
-        LOGGER.info('get_a_payment: {}', return_value)
+        LOGGER.info('get_a_payment: %s', str(return_value))
         return return_value
 
     ##########################################################################


### PR DESCRIPTION
# Description of change
Change payments to be full table stream since you can only query on created time but records can be updated - also addresses https://stitchdata.atlassian.net/browse/SRCE-3579

# Manual QA steps
 - unit / integ tests
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
