### PR TITLE
Stop skipping refunds and payments, adjusted some asserts

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -21,7 +21,7 @@ class TestSquareAllFields(TestSquareBase):
         return self.dynamic_data_streams().difference(
             {  # STREAMS THAT CANNOT CURRENTLY BE TESTED
                 'employees',
-                # 'items',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3586
+                'items',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3606
                 'inventories',
                 'modifier_lists',
             }

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -47,7 +47,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
         for i in range(10):
             print("Polling {} iteration of payments for record: id={}".format(i, rec_id))
-            sleep(10)
+            sleep(2)
             all_payments = self.client.get_all('payments', self.START_DATE)
             records = [payment for payment in all_payments if payment['id'] == rec_id]
             assert len(records) == 1
@@ -178,8 +178,16 @@ class TestSquareIncrementalReplication(TestSquareBase):
             # Update all streams (but save payments for last)
             if stream == 'payments':
                 continue
+            elif stream == 'orders':
+                for message in first_sync_records.get(stream).get('messages'):
+                    if message.get('data')['state'] != 'COMPLETED':
+                        first_rec = message.get('data')
+                        break
 
-            first_rec = first_sync_records.get(stream).get('messages')[0].get('data')
+                if not first_rec:
+                    raise RuntimeError("Unable to find any any orders with state other than COMPLETED")
+            else:
+                first_rec = first_sync_records.get(stream).get('messages')[0].get('data')
             first_rec_id = first_rec.get('id')
             first_rec_version = first_rec.get('version')
             updated_record = self.client.update(stream, first_rec_id, first_rec_version)
@@ -337,7 +345,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
                     # Verify that the inserted records are replicated by the 2nd sync and match our expectations
                     for created_record in created_records.get(stream):
-                        # # BUG | https://stitchdata.atlassian.net/browse/SRCE-3532
                         sync_records = [record for record in second_sync_data
                                         if created_record.get('id') == record.get('id')]
                         self.assertTrue(len(sync_records),
@@ -358,6 +365,11 @@ class TestSquareIncrementalReplication(TestSquareBase):
                             self.assertEqual(len(sync_records), 1,
                                              msg="A duplicate record was found in the sync for {}\nRECORDS: {}.".format(stream, sync_records))
                             sync_record = sync_records[0]
+
+                            # TODO | TEST ISSUE | Address delayed fields in updated payments
+                            if stream == 'payments' and sync_record.get('processing_fee') and updated_record.get('processing_fee') is None:
+                                updated_record['processing_fee'] = updated_record.get('processing_fee')
+
                             self.assertDictEqual(updated_record, sync_record)
 
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -41,15 +41,20 @@ class TestSquareIncrementalReplication(TestSquareBase):
         print("\n\nTEST TEARDOWN\n\n")
 
     def poll_for_updated_record(self, rec_id, start_date):
+        from time import sleep
         all_payments = self.client.get_all('payments', self.START_DATE)
         temp_rec = [payment for payment in all_payments if payment['id'] == rec_id]
 
-        for i in range(3):
-            print("Polling payments for record: id={}".format(rec_id))
-            records = self.client.get_a_payment(rec_id, start_date)
+        for i in range(10):
+            print("Polling {} iteration of payments for record: id={}".format(i, rec_id))
+            sleep(10)
+            all_payments = self.client.get_all('payments', self.START_DATE)
+            records = [payment for payment in all_payments if payment['id'] == rec_id]
             assert len(records) == 1
             record = records[0]
             if len(temp_rec[0].keys()) < len(record.keys()):
+                print("Poll Successful after {} iterations.".format(i))
+                print(set(temp_rec[0].keys()).symmetric_difference(set(record.keys())))
                 break
 
         return records

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -507,15 +507,18 @@ class TestClient(SquareClient):
             raise RuntimeError(resp.errors)
         return resp
 
-    ##########################################################################
-    ### DELETEs
-    ##########################################################################
-
     def update_order(self, location_id, obj_id, version):
         body = {'order': {'note': self.make_id('order'),
                           'version': version},
                 'idempotency_key': str(uuid.uuid4())}
-        return self._client.orders.update_order(location_id=location_id, order_id=obj_id, body=body)
+        resp = self._client.orders.update_order(location_id=location_id, order_id=obj_id, body=body)
+        if resp.is_error():
+            raise RuntimeError(resp.errors)
+        return resp
+
+    ##########################################################################
+    ### DELETEs
+    ##########################################################################
 
     def delete_catalog(self, ids_to_delete):
         body = {'object_ids': ids_to_delete}

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -34,8 +34,6 @@ class TestSquarePagination(TestSquareBase):
         return self.dynamic_data_streams().difference(
             {  # STREAMS NOT CURRENTY TESTABLE
                 'employees', # Requires production environment to create records
-                'refunds',
-                'payments',
                 'modifier_lists',
                 'inventories',
             }
@@ -123,14 +121,6 @@ class TestSquarePagination(TestSquareBase):
             self.assertGreater(record_count, self.API_LIMIT.get(stream),
                                msg="Pagination not ensured.\n" +
                                "{} does not have sufficient data in expecatations.\n ".format(stream))
-
-        # ensure our expectations include any creates that were not explicityly called
-        stream = 'payments'
-        previous_record_count =  len(expected_records.get(stream))
-        if previous_record_count < len(self.client.PAYMENTS):
-            expected_records[stream] = self.client.PAYMENTS
-            added_record_count = previous_record_count - len(expected_records.get(stream))
-            print("Adding {} untracked records to {}".format(added_record_count, stream))
 
         # Create connection but do not use default start date
         conn_id = connections.ensure_connection(self, original_properties=False)


### PR DESCRIPTION
# Description of change
We skipped tests for `refunds` and `payments` in order to get testing branches merged into `master`. With `master` green, this PR adds the tests back

# Manual QA steps
 - Ran tests locally
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
