### PR TITLE
Add using batch create for the inventories - seconds to create 1000 records instead of minutes

### DIFF
--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -1,6 +1,3 @@
-import urllib.parse as urlparse
-from urllib.parse import parse_qs
-
 from datetime import timedelta
 from square.client import Client
 from singer import utils
@@ -9,6 +6,7 @@ import requests
 import urllib.parse
 
 LOGGER = singer.get_logger()
+
 
 def get_batch_token_from_headers(headers):
     link = headers.get('link')
@@ -312,14 +310,6 @@ class SquareClient():
                 raise Exception(result.errors)
 
             yield (result.body.get('payments', []), result.body.get('cursor'))
-
-    def get_batch_token(self, link): #pylint: disable=no-self-use
-        if link:
-            url = link[link.find('<')+1:link.find('>')]
-            parsed = urlparse.urlparse(url)
-            batch_token = parse_qs(parsed.query)['batch_token'][0]
-            return int(batch_token)
-        return None
 
     def get_roles(self, bookmarked_cursor):
         headers = {

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
+import urllib.parse
+
 from square.client import Client
 from singer import utils
 import singer
 import requests
-import urllib.parse
 
 LOGGER = singer.get_logger()
 
@@ -374,7 +375,7 @@ class SquareClient():
 
             yield (result.body.get('items', []), result.body.get('cursor'))
 
-    def get_settlements(self, location_id, start_time, bookmarked_cursor):
+    def get_settlements(self, location_id):
 
         url = 'https://connect.squareup.com/v1/{}/settlements'.format(location_id)
         headers = {

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -31,7 +31,6 @@ class SquareClient():
         self._access_token = self._get_access_token()
         self._client = Client(access_token=self._access_token, environment=self._environment)
 
-
     def _get_access_token(self):
         body = {
             'client_id': self._client_id,

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -106,7 +106,7 @@ class BankAccounts():
     replication_key = None
     object_type = 'BANK ACCOUNTS'
 
-    def sync(self, client, start_time,  bookmarked_cursor): #pylint: disable=unused-argument,no-self-use
+    def sync(self, client, start_time, bookmarked_cursor): #pylint: disable=unused-argument,no-self-use
         for page, cursor in client.get_bank_accounts():
             yield page, cursor
 
@@ -222,7 +222,7 @@ class Settlements:
 
         for location_id in locations.get_all_location_ids(client, start_time, bookmarked_cursor):
             # Settlements requests can only take up to 1 location_id at a time
-            for page, batch_token in client.get_settlements(location_id, start_time, bookmarked_cursor):
+            for page, batch_token in client.get_settlements(location_id):
                 yield page, batch_token
 
 

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -69,13 +69,6 @@ class Employees():
         for page, cursor in client.get_employees(bookmarked_cursor):
             yield page, cursor
 
-class ModifierLists(CatalogStream):
-    tap_stream_id = 'modifier_lists'
-    key_properties = ['id']
-    replication_method = 'INCREMENTAL'
-    valid_replication_keys = ['updated_at']
-    replication_key = 'updated_at'
-    object_type = 'MODIFIER_LIST'
 
 class ModifierLists(CatalogStream):
     tap_stream_id = 'modifier_lists'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -161,7 +161,7 @@ class TestClient(SquareClient):
 
     def create(self, stream, ext_obj=None, start_date=None, end_date=None):
         if stream == 'items':
-            return self.create_item().body.get('objects')
+            return self._create_item(start_date=start_date).body.get('objects')
         elif stream == 'categories':
             return self.create_categories().body.get('objects')
         elif stream == 'discounts':
@@ -173,7 +173,7 @@ class TestClient(SquareClient):
         elif stream == 'employees':
             return self.create_employees().body.get('objects')
         elif stream == 'inventories':
-            return self.create_batch_inventory_adjustment()
+            return self.create_batch_inventory_adjustment(start_date=start_date)
         elif stream == 'locations':
             return [self.create_locations().body.get('location')]
         elif stream == 'orders':
@@ -219,9 +219,9 @@ class TestClient(SquareClient):
             raise RuntimeError('GET INVENTORY_ADJUSTMENT: {}'.format(response.errors))
         return response
 
-    def create_batch_inventory_adjustment(self, num_records):
+    def create_batch_inventory_adjustment(self, start_date, num_records):
         # Create an item
-        items = self.create_item(num_records).body.get('objects', [])
+        items = self._create_item(start_date=start_date, num_records).body.get('objects', [])
         assert(items)
 
         # Crate an item_variation and get it's ID
@@ -394,8 +394,7 @@ class TestClient(SquareClient):
                                                                  ],}
                                           }]}],
 
-    def create_item(self, num_records=1):
-        start_date = '2020-07-29T00:00:00Z'
+    def _create_item(self, start_date, num_records=1):
         mod_lists = self.get_all('modifier_lists', start_date)
         mod_list_id = random.choice(mod_lists).get('id')
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,19 +256,18 @@ class TestClient(SquareClient):
                 datetime.utcnow()-timedelta(hours=random.randint(1,23)), '%Y-%m-%dT%H:00:00Z')
             change = {
                 'type': 'ADJUSTMENT',
-                'ADJUSTMENT': {
-                    'adjustment': {
-                        'from_state': from_state,
-                        'to_state': to_state,
-                        'location_id': loc_id,
-                        'occurred_at': occurred_at,
-                        'catalog_object_id': catalog_obj_id,
-                        'quantity': '1.0',
-                        'source': {
-                            'product': random.choice([
-                                'SQUARE_POS', 'EXTERNAL_API', 'BILLING', 'APPOINTMENTS',
-                                'INVOICES', 'ONLINE_STORE', 'PAYROLL', 'DASHBOARD',
-                                'ITEM_LIBRARY_IMPORT', 'OTHER'])}}},
+                'adjustment': {
+                    'from_state': from_state,
+                    'to_state': to_state,
+                    'location_id': loc_id,
+                    'occurred_at': occurred_at,
+                    'catalog_object_id': catalog_obj_id,
+                    'quantity': '1.0',
+                    'source': {
+                        'product': random.choice([
+                            'SQUARE_POS', 'EXTERNAL_API', 'BILLING', 'APPOINTMENTS',
+                            'INVOICES', 'ONLINE_STORE', 'PAYROLL', 'DASHBOARD',
+                            'ITEM_LIBRARY_IMPORT', 'OTHER'])}},
             }
             changes.append(change)
 
@@ -279,8 +278,10 @@ class TestClient(SquareClient):
                 'ignore_unchanged_counts': random.choice([True, False]),
                 'idempotency_key': str(uuid.uuid4())
             }
+            LOGGER.info("About to create %s inventory adjustments", len(change_chunk))
             response = self._client.inventory.batch_change_inventory(body)
             if response.is_error():
+                LOGGER.error("response had error, body was %s", body)
                 raise RuntimeError(response.errors)
 
             all_counts += response.body.get('counts')
@@ -331,6 +332,9 @@ class TestClient(SquareClient):
 
                 refund = self._client.refunds.refund_payment(body)
                 if refund.is_error(): # Debugging
+                    print("body: {}".format(body))
+                    print("response: {}".format(refund))
+                    print("payment attempted to be refunded: {}".format(payment))
                     raise RuntimeError(refund.errors)
             else:
                 raise RuntimeError(refund.errors)
@@ -367,6 +371,8 @@ class TestClient(SquareClient):
                'note': self.make_id('payment'),}
         new_payment = self._client.payments.create_payment(body)
         if new_payment.is_error():
+            print("body: {}".format(body))
+            print("response: {}".format(new_payment))
             raise RuntimeError(new_payment.errors)
 
         response = new_payment.body.get('payment')
@@ -524,8 +530,9 @@ class TestClient(SquareClient):
         }
         response =  self.post_location(body)
         if response.is_error():
+            print("body: {}".format(body))
+            print("response: {}".format(new_payment))
             raise RuntimeError(response.errors)
-
         return response
 
     def create_employees(self):
@@ -763,6 +770,7 @@ class TestClient(SquareClient):
         }
         response = self._client.inventory.batch_change_inventory(body)
         if response.is_error():
+            print(response.body.get('errors'))
             raise RuntimeError(response.errors)
 
         return response

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -219,9 +219,9 @@ class TestClient(SquareClient):
             raise RuntimeError('GET INVENTORY_ADJUSTMENT: {}'.format(response.errors))
         return response
 
-    def create_batch_inventory_adjustment(self, start_date, num_records):
+    def create_batch_inventory_adjustment(self, start_date, num_records=1):
         # Create an item
-        items = self._create_item(start_date=start_date, num_records).body.get('objects', [])
+        items = self._create_item(start_date, num_records).body.get('objects', [])
         assert(items)
 
         # Crate an item_variation and get it's ID
@@ -393,6 +393,8 @@ class TestClient(SquareClient):
                                                                       'ordinal': 1}
                                                                  ],}
                                           }]}],
+                'idempotency_key': str(uuid.uuid4())}
+        return self.post_category(body)
 
     def _create_item(self, start_date, num_records=1):
         mod_lists = self.get_all('modifier_lists', start_date)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -209,7 +209,8 @@ class TestClient(SquareClient):
     def get_catalog_object(self, obj_id):
         response = self._client.catalog.retrieve_catalog_object(object_id=obj_id)
         if response.is_error():
-            print(response.body.get('errrors'))
+            raise RuntimeError(response.errors)
+
         return response.body.get('object')
 
     def get_an_inventory_adjustment(self, obj_id):
@@ -280,7 +281,7 @@ class TestClient(SquareClient):
             }
             response = self._client.inventory.batch_change_inventory(body)
             if response.is_error():
-                print(response.body.get('errors'))
+                raise RuntimeError(response.errors)
 
             all_counts += response.body.get('counts')
 
@@ -330,9 +331,6 @@ class TestClient(SquareClient):
 
                 refund = self._client.refunds.refund_payment(body)
                 if refund.is_error(): # Debugging
-                    print("body: {}".format(body))
-                    print("response: {}".format(refund))
-                    print("payment attempted to be refunded: {}".format(payment))
                     raise RuntimeError(refund.errors)
             else:
                 raise RuntimeError(refund.errors)
@@ -369,8 +367,6 @@ class TestClient(SquareClient):
                'note': self.make_id('payment'),}
         new_payment = self._client.payments.create_payment(body)
         if new_payment.is_error():
-            print("body: {}".format(body))
-            print("response: {}".format(new_payment))
             raise RuntimeError(new_payment.errors)
 
         response = new_payment.body.get('payment')
@@ -528,8 +524,8 @@ class TestClient(SquareClient):
         }
         response =  self.post_location(body)
         if response.is_error():
-            print("body: {}".format(body))
-            print("response: {}".format(new_payment))
+            raise RuntimeError(response.errors)
+
         return response
 
     def create_employees(self):
@@ -767,7 +763,7 @@ class TestClient(SquareClient):
         }
         response = self._client.inventory.batch_change_inventory(body)
         if response.is_error():
-            print(response.body.get('errors'))
+            raise RuntimeError(response.errors)
 
         return response
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -121,7 +121,7 @@ class TestSquarePagination(TestSquareBase):
                         assert new_object[0], "Failed to create a {} record.\nRECORD: {}".format(stream, new_object[0])
                         new_objects += new_object
                 elif stream == 'inventories':
-                    new_objects = self.client.create_batch_inventory_adjustment(num_records).body.get('counts', [])
+                    new_objects = self.client.create_batch_inventory_adjustment(num_records)
                 elif stream in {'items', 'categories', 'discounts', 'taxes'}:  # catalog objects
                     new_objects = self.client.create_batch_post(stream, num_records).body.get('objects', [])
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -13,13 +13,13 @@ from base import TestSquareBase
 class TestSquarePagination(TestSquareBase):
     """Test that we are paginating for streams when exceeding the API record limit of a single query"""
 
-    BATCH_LIMIT = 1000
+    DEFAULT_BATCH_LIMIT = 1000
     API_LIMIT = {
-        'items': BATCH_LIMIT,
-        'inventories': BATCH_LIMIT,
-        'categories': BATCH_LIMIT,
-        'discounts': BATCH_LIMIT,
-        'taxes': BATCH_LIMIT,
+        'items': DEFAULT_BATCH_LIMIT,
+        'inventories': DEFAULT_BATCH_LIMIT,
+        'categories': DEFAULT_BATCH_LIMIT,
+        'discounts': DEFAULT_BATCH_LIMIT,
+        'taxes': DEFAULT_BATCH_LIMIT,
         'employees': 50,
         'locations': None, # TODO
         'refunds': 100,
@@ -93,18 +93,18 @@ class TestSquarePagination(TestSquareBase):
             expected_records[stream] += existing_objects
 
             if len(existing_objects) <= self.API_LIMIT.get(stream):
-                num_to_post = self.API_LIMIT.get(stream) + 1 - len(existing_objects)
-                print('{}: Will create {} records'.format(stream, num_to_post))
+                num_records = self.API_LIMIT.get(stream) + 1 - len(existing_objects)
+                print('{}: Will create {} records'.format(stream, num_records))
                 new_objects = []
                 if stream == 'orders':
                     location_id = [location['id'] for location in self.client.get_all('locations')][0]
-                    for i in range(num_to_post):
+                    for i in range(num_records):
                         new_objects.append(self.client.create_order(location_id))
                 elif stream == 'shifts':
                     # Find the max end_at to know when the last shift ends, so we can start a shift there
                     max_end_at = max([obj['end_at'] for obj in existing_objects])
                     end_at_datetime = utils.strptime_to_utc(max_end_at)
-                    for i in range(num_to_post):
+                    for i in range(num_records):
                         # Tested in the API Explorer that +00:00 works
                         # How does this work? It feels like it should be new_objects += blah
                         new_objects.append(
@@ -114,21 +114,22 @@ class TestSquarePagination(TestSquareBase):
                         # Bump our known max `end_at` by self.client.SHIFT_MINUTES
                         end_at_datetime = end_at_datetime + timedelta(minutes=self.client.SHIFT_MINUTES)
 
-                elif stream in {'inventories','employees', 'refunds', 'payments'}: # non catalog objectsx
-                    for n in range(num_to_post):
+                elif stream in {'employees', 'refunds', 'payments'}: # non catalog objectsx
+                    for n in range(num_records):
                         print('{}: Created {} records'.format(stream, n))
-                        start_date = self.START_DATE if stream == 'refunds' else None
-                        new_object = self.client.create(stream, start_date=start_date)
+                        new_object = self.client.create(stream, start_date=self.START_DATE)
                         assert new_object[0], "Failed to create a {} record.\nRECORD: {}".format(stream, new_object[0])
                         new_objects += new_object
+                elif stream == 'inventories':
+                    new_objects = self.client.create_batch_inventory_adjustment(num_records).body.get('counts', [])
                 elif stream in {'items', 'categories', 'discounts', 'taxes'}:  # catalog objects
-                    new_objects = self.client.create_batch_post(stream, num_to_post).body.get('objects', [])
+                    new_objects = self.client.create_batch_post(stream, num_records).body.get('objects', [])
 
                 else:
                     raise RuntimeError("The stream {} is missing from the setup.".format(stream))
                 expected_records[stream] += new_objects
 
-                print('{}: Created {} records'.format(stream, num_to_post))
+                print('{}: Created {} records'.format(stream, num_records))
             else:
                 print('{}: Have sufficent amount of data to continue test'.format(stream))
 


### PR DESCRIPTION
# Description of change
Every 3 days it has to recreate 1000+ records, which took us minutes cause it repeats many calls (like get all locations) and also calls create or batch for 1 record * 1000, instead of batching it. This uses the batch apis correct.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
