### PR TITLE
Testing/cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/tap_square/schemas/*.json
       - run:
+          when: always
           name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,20 @@ jobs:
                      tests/test_bookmarks_static.py
       - run:
           when: always
+          name: 'Testing Start Date'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests/test_start_date.py
+      - run:
+          when: always
           name: 'Testing Pagination'
           command: |
             source dev_env.sh

--- a/tap_square/schemas/categories.json
+++ b/tap_square/schemas/categories.json
@@ -30,6 +30,18 @@
         "boolean"
       ]
     },
+    "absent_at_location_ids": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "present_at_all_locations": {
       "type": [
         "null",

--- a/tap_square/schemas/discounts.json
+++ b/tap_square/schemas/discounts.json
@@ -86,6 +86,18 @@
         "boolean"
       ]
     },
+    "absent_at_location_ids": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "present_at_all_locations": {
       "type": [
         "null",

--- a/tap_square/schemas/discounts.json
+++ b/tap_square/schemas/discounts.json
@@ -54,6 +54,18 @@
             "string"
           ]
         },
+        "label_color": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "pin_required": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "percentage": {
           "type": [
             "null",

--- a/tap_square/schemas/items.json
+++ b/tap_square/schemas/items.json
@@ -25,6 +25,18 @@
         ]
       }
     },
+    "absent_at_location_ids": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "version": {
       "type": [
         "null",
@@ -222,6 +234,30 @@
             "string"
           ]
         },
+        "abbreviation": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "available_electronically": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "available_for_pickup": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "available_online": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "skip_modifier_screen": {
           "type": [
             "null",
@@ -233,6 +269,24 @@
             "null",
             "string"
           ]
+        },
+        "label_color": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "tax_ids": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
         },
         "modifier_list_info": {
           "type": [
@@ -247,6 +301,20 @@
               ]
             },
             "modifier_list_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "item_options": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "item_option_id": {
               "type": [
                 "null",
                 "string"

--- a/tap_square/schemas/locations.json
+++ b/tap_square/schemas/locations.json
@@ -79,7 +79,7 @@
             "null",
             "string"
           ]
-        }
+        },
         "address_line_2": {
           "type": [
             "null",

--- a/tap_square/schemas/locations.json
+++ b/tap_square/schemas/locations.json
@@ -79,6 +79,18 @@
             "null",
             "string"
           ]
+        }
+        "address_line_2": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "address_line_3": {
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "postal_code": {
           "type": [
@@ -98,7 +110,61 @@
             "string"
           ]
         },
+        "administrative_district_level_2": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "administrative_district_level_3": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "first_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "last_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "locality": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "organization": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "sublocality": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "sublocality_2": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "sublocality_3": {
           "type": [
             "null",
             "string"

--- a/tap_square/schemas/modifier_lists.json
+++ b/tap_square/schemas/modifier_lists.json
@@ -145,6 +145,18 @@
         }
       }
     },
+    "absent_at_location_ids": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "present_at_all_locations": {
       "type": [
         "null",

--- a/tap_square/schemas/payments.json
+++ b/tap_square/schemas/payments.json
@@ -56,12 +56,6 @@
         "string"
       ]
     },
-    "note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "delay_duration": {
       "type": [
         "null",
@@ -189,6 +183,12 @@
             "string"
           ]
         },
+        "auth_result_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "errors": {
           "type": [
             "null",
@@ -230,6 +230,18 @@
       ]
     },
     "order_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "customer_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reference_id": {
       "type": [
         "null",
         "string"

--- a/tap_square/schemas/taxes.json
+++ b/tap_square/schemas/taxes.json
@@ -16,6 +16,18 @@
         "boolean"
       ]
     },
+    "absent_at_location_ids": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "present_at_all_locations": {
       "type": [
         "null",

--- a/tests/base.py
+++ b/tests/base.py
@@ -347,7 +347,6 @@ class TestSquareBase(unittest.TestCase):
     def align_date_type(self, record, key, value):
         """datetime values must conform to ISO-8601 or they will be rejected by the gate"""
         if isinstance(value, str) and isinstance(self.date_check_and_parse(value), dt):
-            # key in ['updated_at', 'created_at']:
             raw_date = self.date_check_and_parse(value)
             iso_date = dt.strftime(raw_date,  "%Y-%m-%dT%H:%M:%S.%fZ")
             record[key] = iso_date

--- a/tests/base.py
+++ b/tests/base.py
@@ -199,11 +199,13 @@ class TestSquareBase(unittest.TestCase):
         }
 
     def untestable_streams(self):
+        """STREAMS THAT CANNOT CURRENTLY BE TESTED"""
         return {
             'bank_accounts',  # No endpoints for CREATE or UPDATE
             'cash_drawer_shifts',  # Require cash transactions (not supported by API)
             'settlements',  # Depenedent on bank_account related transactions, no endpoints for CREATE or UPDATE
         }
+
     def dynamic_data_streams(self):
         """Expected streams minus streams with static data."""
         return self.expected_streams().difference(self.static_data_streams())
@@ -372,7 +374,7 @@ class TestSquareBase(unittest.TestCase):
 
         for stream in create_test_data_streams:
             expected_records[stream] = self.client.get_all(stream, start_date)
-            rep_key = next(iter(self.expected_replication_keys().get(stream, set('created_at'))))
+            rep_key = next(iter(self.expected_replication_keys().get(stream, {'created_at'})))
             if not any([stream_obj.get(rep_key) and self.parse_date(stream_obj.get(rep_key)) > self.parse_date(start_date_2)
                         for stream_obj in expected_records[stream]]):
                 LOGGER.info("Data missing for stream %s, will create a record", stream)

--- a/tests/base.py
+++ b/tests/base.py
@@ -232,6 +232,15 @@ class TestSquareBase(unittest.TestCase):
                 for table, properties
                 in self.expected_metadata().items()}
 
+    def makeshift_primary_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of primary key fields
+        """
+        return {
+            'inventories': {'catalog_object_id', 'location_id', 'state'}
+        }
+
     def expected_replication_keys(self):
         incremental_streams = self.expected_incremental_streams()
         return {table: properties.get(self.REPLICATION_KEYS, set())

--- a/tests/base.py
+++ b/tests/base.py
@@ -99,10 +99,9 @@ class TestSquareBase(unittest.TestCase):
         """The expected streams and metadata about the streams"""
 
         return {
-            "items": {
+            "bank_accounts": {
                 self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'updated_at'}
+                self.REPLICATION_METHOD: self.FULL,
             },
             "cash_drawer_shifts": {
                 self.PRIMARY_KEYS: {'id'},
@@ -118,33 +117,20 @@ class TestSquareBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'updated_at'}
             },
-            "taxes": {
-                self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'updated_at'}
-            },
             "employees": {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.FULL,
             },
-            "locations": {
-                self.PRIMARY_KEYS: {'id'},
+           "inventories": {
+                self.PRIMARY_KEYS: set(),
                 self.REPLICATION_METHOD: self.FULL,
             },
-            "orders": {
+            "items": {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'updated_at'}
             },
-            "inventories": {
-                self.PRIMARY_KEYS: set(),
-                self.REPLICATION_METHOD: self.FULL,
-            },
-            "refunds": {
-                self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.FULL,
-            },
-            "payments": {
+            "locations": {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.FULL,
             },
@@ -153,13 +139,18 @@ class TestSquareBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'updated_at'}
             },
-            "bank_accounts": {
+            "orders": {
+                self.PRIMARY_KEYS: {'id'},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {'updated_at'}
+            },
+            "payments": {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.FULL,
             },
-            "settlements": {
+            "refunds": {
                 self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.FULL
+                self.REPLICATION_METHOD: self.FULL,
             },
             "roles": {
                 self.PRIMARY_KEYS: {'id'},
@@ -170,6 +161,11 @@ class TestSquareBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.FULL,
             },
             "shifts": {
+                self.PRIMARY_KEYS: {'id'},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {'updated_at'}
+            },
+            "taxes": {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'updated_at'}
@@ -185,8 +181,6 @@ class TestSquareBase(unittest.TestCase):
     def production_streams(self):
         """Some streams can only have data on the production app. We must test these separately"""
         return {
-            'settlements',
-            'bank_accounts',
             'employees',
             'roles',
         }
@@ -202,9 +196,14 @@ class TestSquareBase(unittest.TestCase):
         """
         return {
             'locations',  # Limit 300 objects, DELETES not supported
-            'bank_accounts',  # No endpoints for CREATE or UPDATE
         }
 
+    def untestable_streams(self):
+        return {
+            'bank_accounts',  # No endpoints for CREATE or UPDATE
+            'cash_drawer_shifts',  # Require cash transactions (not supported by API)
+            'settlements',  # Depenedent on bank_account related transactions, no endpoints for CREATE or UPDATE
+        }
     def dynamic_data_streams(self):
         """Expected streams minus streams with static data."""
         return self.expected_streams().difference(self.static_data_streams())

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -38,7 +38,8 @@ if __name__ == "__main__":
         # 'locations',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'payments',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'refunds',  # GET - DONE | CREATE - DONE | UPDATE - NA  | DELETE -
-        'orders'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
+        # 'orders'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
+        'shifts'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
     ]
     print("********** Testing basic functions of test client **********")
     if test_gets:

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -13,7 +13,7 @@ from test_client import TestClient
 # Testing the TestCLient
 ##########################################################################
 if __name__ == "__main__":
-    client = TestClient(env='production')
+    client = TestClient(env='sandbox')
     # START_DATE = '2020-06-24T00:00:00Z'
     START_DATE = datetime.strftime(datetime.utcnow(), '%Y-%m-%dT00:00:00Z')
 
@@ -33,11 +33,12 @@ if __name__ == "__main__":
         # 'categories',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
         # 'discounts',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
         # 'taxes',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        'roles',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
+        # 'roles',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
         # 'employees',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
         # 'locations',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'payments',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'refunds',  # GET - DONE | CREATE - DONE | UPDATE - NA  | DELETE -
+        'orders'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
     ]
     print("********** Testing basic functions of test client **********")
     if test_gets:
@@ -56,7 +57,7 @@ if __name__ == "__main__":
         for _ in range(1):
             for obj in objects_to_test:
                 print("Testing CREATE: {}".format(obj))
-                import pdb; pdb.set_trace() # UNCOMMENT TO RUN 'INTERACTIVELY'
+                # import pdb; pdb.set_trace() # UNCOMMENT TO RUN 'INTERACTIVELY'
                 if obj == 'refunds':
                     payments = client.get_all('payments', start_date=START_DATE)
                 created_obj = client.create(obj, start_date=START_DATE)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -16,19 +16,11 @@ class TestSquareAllFields(TestSquareBase):
         return "tap_tester_square_all_fields"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(
-            {  # STREAMS THAT CANNOT CURRENTLY BE TESTED
-                'cash_drawer_shifts',
-                'settlements'
-            }
-        )
+        return self.dynamic_data_streams().difference(self.untestable_streams())
+
 
     def testable_streams_static(self):
-        return self.static_data_streams().difference(
-            {  # STREAMS THAT CANNOT CURRENTLY BE TESTED
-                'bank_accounts', # Cannot create a record, also PROD ONLY
-            }
-        )
+        return self.static_data_streams().difference(self.untestable_streams())
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -16,7 +16,9 @@ class TestSquareAllFields(TestSquareBase):
         return "tap_tester_square_all_fields"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(self.untestable_streams())
+        return self.dynamic_data_streams().difference(self.untestable_streams()).difference({
+            'orders',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3700
+        })
 
 
     def testable_streams_static(self):

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -87,7 +87,7 @@ class TestSquareAllFields(TestSquareBase):
 
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
         diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        self.assertEqual(0, len(diff), msg="discovered schemas do not match: {}".format(diff))
         print("discovered schemas are OK")
 
         # Select all available fields from all testable streams
@@ -182,10 +182,10 @@ class TestSquareAllFields(TestSquareBase):
                                                    if actual_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_expected_records),
                                         msg="An actual record is missing from our expectations: \nRECORD: {}".format(actual_record))
-                        self.assertEqual(len(stream_expected_records), 1,
+                        self.assertEqual(1, len(stream_expected_records),
                                          msg="A duplicate record was found in our expectations for {}.".format(stream))
                         stream_expected_record = stream_expected_records[0]
-                        self.assertDictEqual(actual_record, stream_expected_record)
+                        self.assertDictEqual(stream_expected_record, actual_record)
 
 
                     # Verify that our expected records were replicated by the tap
@@ -194,7 +194,7 @@ class TestSquareAllFields(TestSquareBase):
                                                  if expected_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_actual_records),
                                         msg="An expected record is missing from the sync: \nRECORD: {}".format(expected_record))
-                        self.assertEqual(len(stream_actual_records), 1,
+                        self.assertEqual(1, len(stream_actual_records),
                                          msg="A duplicate record was found in the sync for {}.".format(stream))
                         stream_actual_record = stream_actual_records[0]
                         self.assertDictEqual(expected_record, stream_actual_record)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -56,17 +56,7 @@ class TestSquareAllFields(TestSquareBase):
         print("WITH STREAMS: {}\n\n".format(self.TESTABLE_STREAMS))
 
         # ensure data exists for sync streams and set expectations
-        expected_records = {x: [] for x in self.expected_streams()} # ids by stream
-        for stream in self.TESTABLE_STREAMS:
-            existing_objects = self.client.get_all(stream, self.START_DATE)
-            if existing_objects:
-                print("Data exists for stream: {}".format(stream))
-                for obj in existing_objects:
-                    expected_records[stream].append(obj)
-            else:
-                print("Data does not exist for stream: {}".format(stream))
-                assert None, "more test functinality needed"
-
+        expected_records = self.create_test_data(self.TESTABLE_STREAMS, self.START_DATE)
         # modify data set to conform to expectations (json standards)
         for stream, records in expected_records.items():
             print("Ensuring expected data for {} has values formatted correctly.".format(stream))

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -18,6 +18,7 @@ class TestSquareAllFields(TestSquareBase):
     def testable_streams(self):
         return self.dynamic_data_streams().difference(self.untestable_streams()).difference({
             'orders',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3700
+            'shifts',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3704
         })
 
 
@@ -108,7 +109,8 @@ class TestSquareAllFields(TestSquareBase):
                 self.assertTrue(field_selected, msg="Field not selected.")
 
         #clear state
-        menagerie.set_state(conn_id, {})
+        version = menagerie.get_state_version(conn_id)
+        menagerie.set_state(conn_id, {}, version)
 
         # run sync
         sync_job_name = runner.run_sync_mode(self, conn_id)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -160,9 +160,9 @@ class TestAutomaticFields(TestSquareBase):
 
                 # Verify that only the automatic fields are sent to the target
                 for actual_keys in record_messages_keys:
-                    self.assertEqual(
-                        actual_keys.symmetric_difference(expected_keys), set(),
-                        msg="Expected automatic fields and nothing else.")
+                    self.assertEqual(set(),
+                                     actual_keys.symmetric_difference(expected_keys),
+                                     msg="Expected automatic fields and nothing else.")
 
                 actual_records = [row['data'] for row in data['messages']]
 
@@ -182,10 +182,10 @@ class TestAutomaticFields(TestSquareBase):
                                                    if actual_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_expected_records),
                                         msg="An actual record is missing from our expectations: \nRECORD: {}".format(actual_record))
-                        self.assertEqual(len(stream_expected_records), 1,
+                        self.assertEqual(1, len(stream_expected_records),
                                          msg="A duplicate record was found in our expectations for {}.".format(stream))
                         stream_expected_record = stream_expected_records[0]
-                        self.assertDictEqual(actual_record, stream_expected_record)
+                        self.assertDictEqual(stream_expected_record, actual_record)
 
                     # Verify that our expected records were replicated by the tap
                     for expected_record in expected_records.get(stream):
@@ -193,7 +193,7 @@ class TestAutomaticFields(TestSquareBase):
                                                  if expected_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_actual_records),
                                         msg="An expected record is missing from the sync: \nRECORD: {}".format(expected_record))
-                        self.assertEqual(len(stream_actual_records), 1,
+                        self.assertEqual(1, len(stream_actual_records),
                                          msg="A duplicate record was found in the sync for {}.".format(stream))
                         stream_actual_record = stream_actual_records[0]
                     self.assertDictEqual(expected_record, stream_actual_record)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -14,19 +14,11 @@ class TestAutomaticFields(TestSquareBase):
         return "tap_tester_square_automatic_fields"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(
-            {  # STREAMS NOT CURRENTY TESTABLE
-                'cash_drawer_shifts',
-                'settlements',
-            }
-        )
+        return self.dynamic_data_streams().difference(self.untestable_streams())
+
 
     def testable_streams_static(self):
-        return self.static_data_streams().difference(
-            {  # STREAMS THAT CANNOT CURRENTLY BE TESTED
-                'bank_accounts', # data cannot be created via API
-            }
-        )
+        return self.static_data_streams().difference(self.untestable_streams())
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
@@ -46,8 +38,6 @@ class TestAutomaticFields(TestSquareBase):
         self.START_DATE = self.get_properties().get('start_date')
         self.TESTABLE_STREAMS = self.testable_streams().difference(self.sandbox_streams())
         self.auto_fields_test()
-
-        # TODO Determine if static prod streams exist
 
 
     def auto_fields_test(self):
@@ -76,7 +66,7 @@ class TestAutomaticFields(TestSquareBase):
             for obj in existing_objects:
                 expected_records[stream].append(
                     {field: obj.get(field)
-                     for field in self.expected_automatic_fields().get(stream)}
+                    for field in self.expected_automatic_fields().get(stream)}
                 )
 
         # Adjust expectations for datetime format

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -224,8 +224,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
             updated_pk_values = {tuple([record.get(pk) for pk in primary_keys]) for record in updated_records[stream]}
             for record in expected_records_first_sync.get(stream, []):
-                if isinstance(record, list):
-                    LOGGER.info("stream %s with list record about to be tupled, record=%s", stream, record)
                 record_pk_values = tuple([record.get(pk) for pk in primary_keys])
                 if record_pk_values in updated_pk_values:
                     continue  # do not add the orginal of the updated record
@@ -353,8 +351,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
                 # Verify that the inserted records are replicated by the 2nd sync and match our expectations
                 for created_record in created_records.get(stream):
-                    if isinstance(created_record, list):
-                        LOGGER.info("stream %s with list record about to be tupled, record=%s", stream, created_record)
                     record_pk_values = tuple([created_record.get(pk) for pk in primary_keys])
                     sync_records = [sync_record for sync_record in second_sync_data
                                     if tuple([sync_record.get(pk) for pk in primary_keys]) == record_pk_values]

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -19,7 +19,9 @@ class TestSquareIncrementalReplication(TestSquareBase):
         return "tap_tester_square_incremental_replication"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(self.untestable_streams())
+        return self.dynamic_data_streams().difference(self.untestable_streams()).difference(
+            {'orders'}  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3700
+        )
 
     def cannot_update_streams(self):
         return {

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -19,9 +19,10 @@ class TestSquareIncrementalReplication(TestSquareBase):
         return "tap_tester_square_incremental_replication"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(self.untestable_streams()).difference(
-            {'orders'}  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3700
-        )
+        return self.dynamic_data_streams().difference(self.untestable_streams()).difference({
+            'orders',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3700
+            'shifts',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3704
+        })
 
     def cannot_update_streams(self):
         return {

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -367,7 +367,9 @@ class TestSquareIncrementalReplication(TestSquareBase):
                     sync_record = sync_records[0]
                     if stream not in self.streams_with_record_differences_after_create():
                         if stream == 'payments':
-                            self.assertPaymentsEqual(created_record, sync_record)
+                            self.assertDictEqualWithOffKeys(created_record,, sync_record, {'updated_at'})
+                        elif stream in {'employees', 'roles'}:
+                            self.assertDictEqualWithOffKeys(created_record,, sync_record, {'created_at', 'updated_at'})
                         else:
                             self.assertDictEqual(created_record, sync_record)
 
@@ -389,9 +391,6 @@ class TestSquareIncrementalReplication(TestSquareBase):
                             self.assertDictEqualWithOffKeys(updated_record, sync_record, {'updated_at'})
                         elif stream == 'inventories':
                             self.assertDictEqualWithOffKeys(updated_record, sync_record, {'calculated_at'})
-                        elif stream in {'employees', 'roles'}:
-
-                            self.assertDictEqualWithOffKeys(updated_record, sync_record, {'created_at', 'updated_at'})
                         else:
                             self.assertDictEqual(updated_record, sync_record)
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -118,7 +118,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
         first_sync_record_count = self.run_sync(conn_id)
 
         # verify that the sync only sent records to the target for selected streams (catalogs)
-        self.assertEqual(set(first_sync_record_count.keys()), streams_to_select,
+        self.assertEqual(streams_to_select, set(first_sync_record_count.keys()),
                          msg="Expect first_sync_record_count keys {} to equal testable streams {},"
                          " first_sync_record_count was {}".format(
                              first_sync_record_count.keys(),
@@ -248,13 +248,13 @@ class TestSquareIncrementalReplication(TestSquareBase):
         for stream in self.TESTABLE_STREAMS:
             if stream in self.expected_incremental_streams():
                 if stream in self.cannot_update_streams():
-                    self.assertEqual(len(expected_records_second_sync.get(stream)), 1,
+                    self.assertEqual(1, len(expected_records_second_sync.get(stream)),
                                      msg="Expectations are invalid for incremental stream {}".format(stream))
                 elif stream == 'orders': # ORDERS are returned inclusive on the datetime queried
-                    self.assertEqual(len(expected_records_second_sync.get(stream)), 3,
+                    self.assertEqual(3, len(expected_records_second_sync.get(stream)),
                                      msg="Expectations are invalid for incremental stream {}".format(stream))
                 else:  # Most streams will have 2 records from the Update and Insert
-                    self.assertEqual(len(expected_records_second_sync.get(stream)), 2,
+                    self.assertEqual(2, len(expected_records_second_sync.get(stream)),
                                      msg="Expectations are invalid for incremental stream {}".format(stream))
             if stream in self.expected_full_table_streams():
                 self.assertEqual(len(expected_records_second_sync.get(stream)), len(expected_records_first_sync.get(stream)) + len(created_records[stream]),
@@ -320,12 +320,12 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
                     # Verify no bookmarks are present
                     first_state = first_sync_state.get('bookmarks', {}).get(stream)
-                    self.assertEqual(first_state, {},
+                    self.assertEqual({}, first_state,
                                      msg="Unexpected state for {}\n".format(stream) + \
                                      "\tState: {}\n".format(first_sync_state) + \
                                      "\tBookmark: {}".format(first_state))
                     second_state = second_sync_state.get('bookmarks', {}).get(stream)
-                    self.assertEqual(second_state, {},
+                    self.assertEqual({}, second_state
                                      msg="Unexpected state for {}\n".format(stream) + \
                                      "\tState: {}\n".format(second_sync_state) + \
                                      "\tBookmark: {}".format(second_state))
@@ -364,7 +364,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
                                     if tuple([sync_record.get(pk) for pk in primary_keys]) == record_pk_values]
                     self.assertTrue(len(sync_records),
                                     msg="An inserted record is missing from our sync: \nRECORD: {}".format(created_record))
-                    self.assertEqual(len(sync_records), 1,
+                    self.assertEqual(1, len(sync_records),
                                      msg="A duplicate record was found in the sync for {}\nRECORD: {}.".format(stream, sync_records))
                     sync_record = sync_records[0]
                     if stream not in self.streams_with_record_differences_after_create():
@@ -382,7 +382,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
                         if stream != 'modifier_lists':
                             self.assertTrue(len(sync_records),
                                             msg="An updated record is missing from our sync: \nRECORD: {}".format(updated_record))
-                            self.assertEqual(len(sync_records), 1,
+                            self.assertEqual(1, len(sync_records),
                                              msg="A duplicate record was found in the sync for {}\nRECORDS: {}.".format(stream, sync_records))
 
                         sync_record = sync_records[0]

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -325,7 +325,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
                                      "\tState: {}\n".format(first_sync_state) + \
                                      "\tBookmark: {}".format(first_state))
                     second_state = second_sync_state.get('bookmarks', {}).get(stream)
-                    self.assertEqual({}, second_state
+                    self.assertEqual({}, second_state,
                                      msg="Unexpected state for {}\n".format(stream) + \
                                      "\tState: {}\n".format(second_sync_state) + \
                                      "\tBookmark: {}".format(second_state))

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -383,11 +383,14 @@ class TestSquareIncrementalReplication(TestSquareBase):
             self.assertDictEqual(expected_record, sync_record)
 
     def assertDictEqualWithOffKeys(self, expected_record, sync_record, off_keys=set()):
-        self.assertEqual(frozenset(expected_record.keys()), frozenset(sync_record.keys()), "Expected keys in expected_record to equal keys in sync_record. [expected_record={}][sync_record={}]".format(expected_record, sync_record))
+        self.assertEqual(frozenset(expected_record.keys()), frozenset(sync_record.keys()),
+                         msg="Expected keys in expected_record to equal keys in sync_record. " +\
+                         "[expected_record={}][sync_record={}]".format(expected_record, sync_record))
         expected_record_copy = deepcopy(expected_record)
         sync_record_copy = deepcopy(sync_record)
 
-        # Square api workflow updates these values so they're a few seconds different between the time the record is created and the tap syncs, but other fields are the same
+        # Square api workflow updates these values so they're a few seconds different between
+        # the time the record is created and the tap syncs, but other fields are the same
         for off_key in off_keys:
             self.assertGreaterEqual(sync_record_copy.pop(off_key),
                                     expected_record_copy.pop(off_key))

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -207,7 +207,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
         # adjust expectations for full table streams to include the expected records from sync 1
         for stream in self.expected_full_table_streams():
             if stream == 'inventories':
-                primary_keys = {'catalog_object_id', 'location_id', 'state'}
+                primary_keys = self.makeshift_primary_keys().get(stream)
             else:
                 primary_keys = list(self.expected_primary_keys().get(stream))
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -19,10 +19,8 @@ class TestSquareIncrementalReplication(TestSquareBase):
         return "tap_tester_square_incremental_replication"
 
     def testable_streams(self):
-        return self.dynamic_data_streams().difference(
+        return self.dynamic_data_streams().difference(self.untestable_streams()).difference(
             {  # STREAMS NOT CURRENTY TESTABLE
-                'cash_drawer_shifts', # TODO
-                'settlements', # TODO
                 'employees',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3673
                 'roles',  # BUG | https://stitchdata.atlassian.net/browse/SRCE-3673
             }

--- a/tests/test_bookmarks_static.py
+++ b/tests/test_bookmarks_static.py
@@ -99,7 +99,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
         first_sync_record_count = self.run_sync(conn_id)
 
         # verify that the sync only sent records to the target for selected streams (catalogs)
-        self.assertEqual(set(first_sync_record_count.keys()), streams_to_select,
+        self.assertEqual(streams_to_select, set(first_sync_record_count.keys()),
                          msg="Expect first_sync_record_count keys {} to equal testable streams {},"
                          " first_sync_record_count was {}".format(
                              first_sync_record_count.keys(),
@@ -161,12 +161,12 @@ class TestSquareIncrementalReplication(TestSquareBase):
 
                     # Verify no bookmarks are present
                     first_state = first_sync_state.get('bookmarks', {}).get(stream)
-                    self.assertEqual(first_state, {},
+                    self.assertEqual({}, first_state,
                                      msg="Unexpected state for {}\n".format(stream) + \
                                      "\tState: {}\n".format(first_sync_state) + \
                                      "\tBookmark: {}".format(first_state))
                     second_state = second_sync_state.get('bookmarks', {}).get(stream)
-                    self.assertEqual(second_state, {},
+                    self.assertEqual({}, second_state,
                                      msg="Unexpected state for {}\n".format(stream) + \
                                      "\tState: {}\n".format(second_sync_state) + \
                                      "\tBookmark: {}".format(second_state))

--- a/tests/test_bookmarks_static.py
+++ b/tests/test_bookmarks_static.py
@@ -17,11 +17,7 @@ class TestSquareIncrementalReplication(TestSquareBase):
         return "tap_tester_square_incremental_replication"
 
     def testable_streams(self):
-        return self.static_data_streams().difference(
-            {  # STREAMS THAT CANNOT CURRENTLY BE TESTED
-                'bank_accounts', # Cannot create a record, also PROD ONLY
-            }
-        )
+        return self.static_data_streams().difference(self.untestable_streams())
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -398,7 +398,7 @@ class TestClient(SquareClient):
 
         return payments
 
-    def _create_payment(self, autocomplete=False, source_key=None):
+    def _create_payment(self, autocomplete=False, source_key='card'):
         """
         Generate a pyament object
         : param autocomplete: boolean
@@ -406,14 +406,10 @@ class TestClient(SquareClient):
         """
         source = {
             'card': 'cnon:card-nonce-ok',
-            #'card_on_file': 'cnon:card-nonce-ok',
-            #'gift_card': 'cnon:gift-card-nonce-ok'
+            'card_on_file': 'cnon:card-nonce-ok',
+            'gift_card': 'cnon:gift-card-nonce-ok'
         }
-
-        if source_key:
-            source_id = source.get(source_key)
-        else:
-            source_id = random.choice(list(source.values()))
+        source_id = source.get(source_key)
         body ={'id': self.make_id('payment'),
                'idempotency_key': str(uuid.uuid4()),
                'amount_money': {'amount': random.randint(100,10000), # in cents

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,7 +231,7 @@ class TestClient(SquareClient):
         elif stream == 'payments':
             return self.create_payments(num_records)
         elif stream == 'shifts':
-            return self.create_shift(num_records, start_date, end_date)
+            return self.create_shift(start_date, end_date, num_records)
         else:
             raise NotImplementedError("create not implemented for stream {}".format(stream))
 
@@ -684,7 +684,7 @@ class TestClient(SquareClient):
 
         return created_orders
 
-    def create_shift(self, num_records, start_date, end_date):
+    def create_shift(self, start_date, end_date, num_records):
         employee_id = [employee['id'] for employee in self.get_all('employees', start_date)][0]
         all_location_ids = [location['id'] for location in self.get_all('locations', start_date)]
         all_shifts = self.get_all('shifts', start_date)
@@ -943,7 +943,7 @@ class TestClient(SquareClient):
 
     def update_shift(self, obj):
         body = {
-            "shift": { # TODO: Can this be obj with the title updated?
+            "shift": {
                 "employee_id": obj['employee_id'],
                 "location_id": obj['location_id'],
                 "start_at": obj['start_at'],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -124,24 +124,24 @@ class TestClient(SquareClient):
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
 
-    def get_a_payment(self, payment_id, start_date, keys_exist=set(), **kwargs):
+    def get_object_matching_conditions(self, stream, object_id, start_date, keys_exist=set(), **kwargs):
         while True:
-            LOGGER.info('get_a_payment: Calling API')
-            all_payments = self.get_all('payments', start_date)
-            found_payment = [payment for payment in all_payments if payment['id'] == payment_id]
-            if not found_payment:
-                LOGGER.warn("Payment with id %s not found, retrying", payment_id)
+            LOGGER.info('get_object_matching_conditions: Calling %s API in retry loop', stream)
+            all_objects = self.get_all(stream, start_date)
+            found_object = [object for object in all_objects if object['id'] == object_id]
+            if not found_object:
+                LOGGER.warn("Stream %s Object with id %s not found, retrying", stream, object_id)
                 continue
 
-            if not set(found_payment[0].keys()).issuperset(keys_exist):
-                LOGGER.warn("Payment with id %s doesn't have enough keys, [payment=%s][keys_exist=%s]", payment_id, found_payment[0], keys_exist)
+            if not set(found_object[0].keys()).issuperset(keys_exist):
+                LOGGER.warn("Stream %s Object with id %s doesn't have enough keys, [object=%s][keys_exist=%s]", stream, object_id, found_object[0], keys_exist)
                 continue
 
-            if all([found_payment[0].get(key) == value for key, value in kwargs.items()]):
-                LOGGER.info('get_a_payment found payment successfully: %s', found_payment)
-                return found_payment
+            if all([found_object[0].get(key) == value for key, value in kwargs.items()]):
+                LOGGER.info('get_object_matching_conditions found %s object successfully: %s', stream, found_object)
+                return found_object
             else:
-                LOGGER.warn("Payment with id %s doesn't have matching keys and values from the expectation, will poll again [expected key-values: kwargs=%s][found_payment=%s]", payment_id, kwargs, found_payment[0]) 
+                LOGGER.warn("Stream %s Object with id %s doesn't have matching keys and values from the expectation, will poll again [expected key-values: kwargs=%s][found_object=%s]", stream, object_id, kwargs, found_object[0]) 
     ##########################################################################
     ### CREATEs
     ##########################################################################
@@ -225,7 +225,7 @@ class TestClient(SquareClient):
             refunds = []
             for _ in range(num_records):
                 (created_refund, _) = self.create_refund(start_date)
-                refunds.append(created_refund)
+                refunds += created_refund
             return refunds
         elif stream == 'payments':
             return self.create_payments(num_records)
@@ -350,7 +350,7 @@ class TestClient(SquareClient):
         """
         # SETUP
         payment_response = self._create_payment(autocomplete=True, source_key="card")
-        payment_obj = self.get_a_payment(payment_id=payment_response.get('id'), start_date=start_date, status='COMPLETED')[0]
+        payment_obj = self.get_object_matching_conditions('payments', payment_response.get('id'), start_date=start_date, status='COMPLETED')[0]
 
         payment_id = payment_obj.get('id')
         payment_amount = payment_obj.get('amount_money').get('amount')
@@ -387,8 +387,9 @@ class TestClient(SquareClient):
             else:
                 raise RuntimeError(refund.errors)
 
-        updated_payment_obj = self.get_a_payment(payment_id=payment_response.get('id'), start_date=start_date, keys_exist={'processing_fee'}, status='COMPLETED', refunded_money=amount_money)[0]
-        return (refund.body.get('refund'), updated_payment_obj)
+        completed_refund = self.get_object_matching_conditions('refunds', refund.body.get('refund').get('id'), start_date=start_date, keys_exist={'processing_fee'}, status='COMPLETED')
+        completed_payment = self.get_object_matching_conditions('payments', payment_response.get('id'), start_date=start_date, keys_exist={'processing_fee'}, status='COMPLETED', refunded_money=amount_money)[0]
+        return (completed_refund, completed_payment)
 
     def create_payments(self, num_records):
         payments = []
@@ -630,11 +631,7 @@ class TestClient(SquareClient):
                 raise Exception(resp.text)
 
             response = resp.json() # account for v1 to v2 changes
-            response['location_ids'] = response.get('authorized_location_ids', [])  # authorized_location_ids -> location_ids
-            del response['authorized_location_ids']
-            del response['role_ids']  # role_ids exists in v1 only
-
-            employees.append(response)
+            employees.append(self.convert_employees_v1_to_v2(response))
         return employees
 
     def create_roles_v1(self, num_records):
@@ -774,7 +771,7 @@ class TestClient(SquareClient):
         start_date = payment_from_response['created_at']
         expected_keys_exist = {'receipt_number', 'receipt_url', 'processing_fee'} if expected_status == 'COMPLETED' else set()
 
-        return self.get_a_payment(payment_id=obj_id, start_date=start_date, keys_exist=expected_keys_exist, status=expected_status)
+        return self.get_object_matching_conditions('payments', obj_id, start_date=start_date, keys_exist=expected_keys_exist, status=expected_status)
 
     def update_categories(self, obj_id, version):
         body = {'batches': [{'objects': [{'id': obj_id,
@@ -802,7 +799,14 @@ class TestClient(SquareClient):
         data = {'first_name': uid,
                 'last_name': obj.get('last_name')}
 
-        return self._update_object_v1("employees", employee_id, data)
+        response = self._update_object_v1("employees", employee_id, data)
+        return self.convert_employees_v1_to_v2(response)
+
+    def convert_employees_v1_to_v2(self, employee_v1_response):
+        employee_v1_response['location_ids'] = employee_v1_response.get('authorized_location_ids', [])  # authorized_location_ids -> location_ids
+        del employee_v1_response['authorized_location_ids']
+        del employee_v1_response['role_ids']  # role_ids exists in v1 only
+        return employee_v1_response
 
     def update_roles_v1(self, obj):
         role_id = obj.get('id')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -412,7 +412,7 @@ class TestClient(SquareClient):
 
     def create_modifier_list(self, num_records):
         objects = []
-        for _ in range(num_records):
+        for n in range(num_records):
             mod_id = self.make_id('modifier')
             list_id = self.make_id('modifier_lists')
             objects.append(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -806,13 +806,14 @@ class TestClient(SquareClient):
 
     def update_roles_v1(self, obj):
         role_id = obj.get('id')
-        uid = self.make_id(endpoint)[1:]
+        uid = self.make_id('role')[1:]
         data = {
             'name': 'updated_' + uid,
         }
-        return self._update_object_v1("roles", rol_id, data)
+        return self._update_object_v1("roles", role_id, data)
 
-    def update_modifier_list(self, obj): # TODO try v1 endpoint in produciton env
+    def update_modifier_list(self, obj, version): # TODO try v1 endpoint in produciton env
+        obj_id = obj.get('id')
         body = {'batches': [{'objects': [{'id': obj_id,
                                          'type': 'MODIFIER_LIST',
                                           'version': version,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ typesToKeyMap = {
 class TestClient(SquareClient):
     # This is the duration of a shift, we make this constant so we can
     # ensure the shifts don't overlap
-    SHIFT_MINUTES = 2
+    SHIFT_MINUTES = 10
 
     """
     Client used to perfrom GET, CREATE and UPDATE on streams.
@@ -729,6 +729,14 @@ class TestClient(SquareClient):
                     'location_id': location_id,
                     'start_at': start_at, # This can probably be derived from the test's start date
                     'end_at': end_at,
+                    'breaks': [{
+                        "start_at": self.shift_date(start_at, 1),
+                        "end_at": self.shift_date(start_at, 2),
+                        "name": "Tea Break",
+                        "expected_duration": "PT5M",
+                        "break_type_id": self.make_id('shift.break'),
+                        "is_paid": True
+                    }],
                     'wage': {
                         'title': self.make_id('shift'),
                         'hourly_rate' : {

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -39,8 +39,9 @@ class TestSquarePagination(TestSquareBase):
         return self.dynamic_data_streams().difference(self.untestable_streams())
 
     def testable_streams_static(self):
-        testable_streams = self.static_data_streams().difference(self.untestable_streams())
-        return testable_streams.difference({'locations'})  # Locations does not paginate
+        return self.static_data_streams().difference(self.untestable_streams()).difference({
+            'locations',  # This stream does not paginate in the sync (See Above)
+        })
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
@@ -178,13 +179,8 @@ class TestSquarePagination(TestSquareBase):
         expected_pks_set = set(expected_pks)
         self.assertEqual(len(expected_pks), len(expected_pks_set), msg="Our expectations contain a duplicate record.")
 
-        # Verify that all expected records were replicated
-        self.assertEqual(set(), expected_pks_set.difference(actual_pks_set),
-                         msg="Our expectations have more unique records than the tap replicated.")
-
-        # Verify ONLY expected records were replicated
-        self.assertEqual(set(), actual_pks_set.difference(expected_pks_set),
-                         msg="The tap replicated data that was not in our expectations.")
+        # Verify that all expected records and ONLY the expected records were replicated
+        self.assertEqual(expected_pks_set, actual_pks_set)
 
 
 if __name__ == '__main__':

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -63,7 +63,7 @@ class TestSquarePagination(TestSquareBase):
         self.pagination_test()
 
         print("\n\n-- SKIPPING -- TESTING WITH STATIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
-        self.TESTABLE_STREAMS = self.testable_streams_static().difference(self.sandbox_streams()),
+        self.TESTABLE_STREAMS = self.testable_streams_static().difference(self.sandbox_streams())
         self.assertEqual(set(), self.TESTABLE_STREAMS,
                          msg="Testable streams exist for this category.")
         print("\tThere are no testable streams.")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -93,7 +93,7 @@ class TestSquarePagination(TestSquareBase):
                 new_objects = self.client.create(stream, start_date=self.START_DATE, num_records=num_records)
 
                 assert new_objects, "Failed to create any new records for stream {}".format(stream)
-                self.assertEqual(len(new_objects), num_records, "Mismatched number of new objects created for stream {}".format(stream))
+                self.assertEqual(num_records, len(new_objects), "Mismatched number of new objects created for stream {}".format(stream))
                 expected_records[stream] += new_objects
             else:
                 LOGGER.info('%s: Have sufficent amount of data to continue test', stream)
@@ -123,7 +123,7 @@ class TestSquarePagination(TestSquareBase):
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
 
         diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        self.assertEqual(0, len(diff), msg="discovered schemas do not match: {}".format(diff))
         print("discovered schemas are OK")
 
         #select all catalogs
@@ -164,8 +164,8 @@ class TestSquarePagination(TestSquareBase):
                                     msg="A paginated synced stream has a record that is missing automatic fields.")
 
                     # Verify we have more fields sent to the target than just automatic fields (this is set above)
-                    self.assertEqual(auto_fields.difference(actual_keys),
-                                     set(), msg="A paginated synced stream has a record that is missing expected fields.")
+                    self.assertEqual(set(), auto_fields.difference(actual_keys),
+                                     msg="A paginated synced stream has a record that is missing expected fields.")
 
                 # Verify by pks that the data replicated matches what we expect
                 primary_keys = self.expected_primary_keys().get(stream)
@@ -178,10 +178,10 @@ class TestSquarePagination(TestSquareBase):
                                                    if actual_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_expected_records),
                                         msg="An actual record is missing from our expectations: \nRECORD: {}".format(actual_record))
-                        self.assertEqual(len(stream_expected_records), 1,
+                        self.assertEqual(1, len(stream_expected_records),
                                          msg="A duplicate record was found in our expectations for {}.".format(stream))
                         stream_expected_record = stream_expected_records[0]
-                        self.assertEqual(actual_record.get(pk), stream_expected_record)
+                        self.assertEqual(stream_expected_record, actual_record.get(pk))
 
                     # Verify that our expected records were replicated by the tap
                     for expected_record in expected_records.get(stream):
@@ -189,7 +189,7 @@ class TestSquarePagination(TestSquareBase):
                                                  if expected_record.get(pk) == record.get(pk)]
                         self.assertTrue(len(stream_actual_records),
                                         msg="An expected record is missing from the sync: \nRECORD: {}".format(expected_record))
-                        self.assertEqual(len(stream_actual_records), 1,
+                        self.assertEqual(1, len(stream_actual_records),
                                          msg="A duplicate record was found in the sync for {}.".format(stream))
                         stream_actual_record = stream_actual_records[0]
                         self.assertEqual(expected_record.get(pk), stream_actual_record)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -158,7 +158,7 @@ class TestSquarePagination(TestSquareBase):
                 if pk:
 
                     # Verify by pks that the replicated records match our expectations
-                    self.assertRecordsEqualByPK(expected_records.get(stream), actual_records, pk)
+                    self.assertRecordsEqualByPK(stream, expected_records.get(stream), actual_records, pk)
 
                 # Verify the expected number of records were replicated
                 self.assertEqual(len(expected_records.get(stream)), len(actual_records))
@@ -188,7 +188,7 @@ class TestSquarePagination(TestSquareBase):
 
                         instances = 0
 
-    def assertRecordsEqualByPK(self, expected_records, actual_records, pk):
+    def assertRecordsEqualByPK(self, stream, expected_records, actual_records, pk):
         """
         Verify all replicated records are accounted for in our expectations.
         Verfy all expected records were replicated.

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -39,7 +39,8 @@ class TestSquarePagination(TestSquareBase):
         return self.dynamic_data_streams().difference(self.untestable_streams())
 
     def testable_streams_static(self):
-        return self.static_data_streams().difference(self.untestable_streams())
+        testable_streams = self.static_data_streams().difference(self.untestable_streams())
+        return testable_streams.difference({'locations'})  # Locations does not paginate
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
@@ -48,11 +49,11 @@ class TestSquarePagination(TestSquareBase):
         self.TESTABLE_STREAMS = self.testable_streams().difference(self.production_streams())
         self.pagination_test()
 
-        print("\n\nTESTING WITH STATIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
-        # TODO Uncomment once TASK addressed https://stitchdata.atlassian.net/browse/SRCE-3575
-        # self.START_DATE = self.STATIC_START_DATE
-        # self.TESTABLE_STREAMS = self.testable_streams_static().difference(self.production_streams())
-        # self.pagination_test()
+        print("\n\n-- SKIPPING -- TESTING WITH STATIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+        self.TESTABLE_STREAMS = self.testable_streams_static().difference(self.production_streams())
+        self.assertEqual(set(), self.TESTABLE_STREAMS,
+                         msg="Testable streams exist for this category.")
+        print("\tThere are no testable streams.")
 
         self.set_environment(self.PRODUCTION)
 
@@ -61,6 +62,11 @@ class TestSquarePagination(TestSquareBase):
         self.TESTABLE_STREAMS = self.testable_streams().difference(self.sandbox_streams())
         self.pagination_test()
 
+        print("\n\n-- SKIPPING -- TESTING WITH STATIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+        self.TESTABLE_STREAMS = self.testable_streams_static().difference(self.sandbox_streams()),
+        self.assertEqual(set(), self.TESTABLE_STREAMS,
+                         msg="Testable streams exist for this category.")
+        print("\tThere are no testable streams.")
 
     def pagination_test(self):
         """

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -182,12 +182,14 @@ class TestSquareStartDate(TestSquareBase):
 
         state_2 = menagerie.get_state(conn_id)
 
+        replication_keys = self.expected_replication_keys()
+
         for stream in self.TESTABLE_STREAMS:
             with self.subTest(stream=stream):
                 replication_type = self.expected_replication_method().get(stream)
+                comparison_key = next(iter(replication_keys.get(stream, {'created_at'})))
                 record_count_1 = record_count_by_stream_1.get(stream, 0)
                 record_count_2 = record_count_by_stream_2.get(stream, 0)
-
 
                 # Verify that the 2nd sync resutls in less records than the 1st sync.
                 self.assertLessEqual(record_count_2, record_count_1,
@@ -198,41 +200,32 @@ class TestSquareStartDate(TestSquareBase):
                                 "Sync 2 start_date: {} ".format(self.START_DATE_2) +
                                 "Sync 2 record_count: {}".format(record_count_2))
 
-
-                # Testing how FULL TABLE streams handle start date
-                if replication_type == self.FULL:
-
-                    # Verify that a bookmark doesn't exist for the stream.
-                    self.assertTrue(state_1.get(stream) is None,
-                                    msg="There should not be bookmark value for {}\n{}".format(stream, state_1.get(stream)))
-                    self.assertTrue(state_2.get(stream) is None,
-                                    msg="There should not be bookmark value for {}\n{}".format(stream, state_1.get(stream)))
-
-                    # TODO Why do full table streams not respect the start date?
-
-                # Testing how INCREMENTAL streams handle start date
-                elif replication_type == self.INCREMENTAL:
-
-                    # Verify 1st sync record count > 2nd sync record count since the 1st start date is older than the 2nd.
+                # Verify 1st sync record count > 2nd sync record count for incremental streams
+                if replication_type == self.INCREMENTAL:
                     self.assertGreater(replicated_row_count_1, replicated_row_count_2, msg="Expected less records on 2nd sync.")
 
-                    # Verify all data from first sync has bookmark values >= start_date .
-                    records_from_sync_1 = set(row.get('data').get('updated_at')
-                                              for row in synced_records_1.get(stream, []).get('messages', []))
-                    for record in records_from_sync_1:
-                        self.assertGreaterEqual(self.parse_date(record), self.parse_date(self.START_DATE_1),
-                                                msg="Record was created prior to start date for 1st sync.\n" +
-                                                "Sync 1 start_date: {}\n".format(self.START_DATE_1) +
-                                                "Record bookmark: {} ".format(record))
-
-                    # Verify all data from second sync has bookmark values >= start_date 2.
-                    records_from_sync_2 = set(row.get('data').get('updated_at')
-                                              for row in synced_records_2.get(stream, {}).get('messages', []))
-                    for record in records_from_sync_2:
-                        self.assertGreaterEqual(self.parse_date(record), self.parse_date(self.START_DATE_2),
-                                                msg="Record was created prior to start date for 2nd sync.\n" +
-                                                "Sync 2 start_date: {}\n".format(self.START_DATE_2) +
-                                                "Record bookmark: {} ".format(record))
-                else:
+                elif replication_type != self.FULL:
                     raise Exception("Expectations are set incorrectly. {} cannot have a "
                                     "replication method of {}".format(stream, replication_type))
+
+                # Skip the remaining assertions for inventories since it is append only and has no reliable datetime field
+                if stream == 'inventories':
+                    continue
+
+                # Verify all data from first sync has bookmark values >= start_date .
+                records_from_sync_1 = set(row.get('data').get(comparison_key)
+                                          for row in synced_records_1.get(stream, []).get('messages', []))
+                for record in records_from_sync_1:
+                    self.assertGreaterEqual(self.parse_date(record), self.parse_date(self.START_DATE_1),
+                                            msg="Record was created prior to start date for 1st sync.\n" +
+                                            "Sync 1 start_date: {}\n".format(self.START_DATE_1) +
+                                            "Record bookmark: {} ".format(record))
+
+                # Verify all data from second sync has bookmark values >= start_date 2.
+                records_from_sync_2 = set(row.get('data').get(comparison_key)
+                                          for row in synced_records_2.get(stream, {}).get('messages', []))
+                for record in records_from_sync_2:
+                    self.assertGreaterEqual(self.parse_date(record), self.parse_date(self.START_DATE_2),
+                                            msg="Record was created prior to start date for 2nd sync.\n" +
+                                            "Sync 2 start_date: {}\n".format(self.START_DATE_2) +
+                                            "Record bookmark: {} ".format(record))

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -92,7 +92,7 @@ class TestSquareStartDate(TestSquareBase):
 
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
         diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        self.assertEqual(0, len(diff), msg="discovered schemas do not match: {}".format(diff))
         print("discovered schemas are OK")
 
         # Select all testable streams and their fields
@@ -150,7 +150,7 @@ class TestSquareStartDate(TestSquareBase):
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
 
         diff = self.expected_check_streams().symmetric_difference(found_catalog_names)
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        self.assertEqual(0, len(diff), msg="discovered schemas do not match: {}".format(diff))
         print("discovered schemas are kosher")
 
         # Select all available streams and their fields

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -217,7 +217,7 @@ class TestSquareStartDate(TestSquareBase):
                 # BUG | https://stitchdata.atlassian.net/browse/SRCE-3681
                 # Skipping these two streams until BUG resolved.
                 # NOTE: we skip inventories ^ for a different reason leave that as is
-                if stream in {'roles', 'employees'}: # TODO REMOVE
+                if stream in {'roles', 'employees', 'locations'}: # TODO REMOVE
                     continue
 
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -208,9 +208,18 @@ class TestSquareStartDate(TestSquareBase):
                     raise Exception("Expectations are set incorrectly. {} cannot have a "
                                     "replication method of {}".format(stream, replication_type))
 
-                # Skip the remaining assertions for inventories since it is append only and has no reliable datetime field
+
+                # Skip the remaining assertions for inventories since it is append only
                 if stream == 'inventories':
                     continue
+
+
+                # BUG | https://stitchdata.atlassian.net/browse/SRCE-3681
+                # Skipping these two streams until BUG resolved.
+                # NOTE: we skip inventories ^ for a different reason leave that as is
+                if stream in {'roles', 'employees'}: # TODO REMOVE
+                    continue
+
 
                 # Verify all data from first sync has bookmark values >= start_date .
                 records_from_sync_1 = set(row.get('data').get(comparison_key)


### PR DESCRIPTION
# Description of change
Cleanup testable streams diffs. 
Add tests to catch duplicate pages of data in pagination test.
Fix start date test to ensure full table streams respect start date.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
