### PR TITLE
Remove prod app from tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -84,8 +84,8 @@ class TestSquareBase(unittest.TestCase):
         if environment in ['sandbox', 'production']:
             creds =  {
                 'refresh_token': os.getenv('TAP_SQUARE_REFRESH_TOKEN') if environment == 'sandbox' else os.getenv('TAP_SQUARE_PROD_REFRESH_TOKEN'),
-                'client_id': os.getenv('TAP_SQUARE_APPLICATION_ID') if environment == 'sandbox' else os.getenv('TAP_SQUARE_PROD_APPLICATION_ID'),
-                'client_secret': os.getenv('TAP_SQUARE_APPLICATION_SECRET') if environment == 'sandbox' else os.getenv('TAP_SQUARE_PROD_APPLICATION_SECRET'),
+                'client_id': os.getenv('TAP_SQUARE_APPLICATION_ID'),
+                'client_secret': os.getenv('TAP_SQUARE_APPLICATION_SECRET'),
                 }
         else:
             raise Exception("Square Environment: {} is not supported.".format(environment))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,8 +62,8 @@ class TestClient(SquareClient):
     def __init__(self, env):
         config = {
             'refresh_token': os.getenv('TAP_SQUARE_REFRESH_TOKEN') if env == 'sandbox' else os.getenv('TAP_SQUARE_PROD_REFRESH_TOKEN'),
-            'client_id': os.getenv('TAP_SQUARE_APPLICATION_ID') if env == 'sandbox' else os.getenv('TAP_SQUARE_PROD_APPLICATION_ID'),
-            'client_secret': os.getenv('TAP_SQUARE_APPLICATION_SECRET') if env == 'sandbox' else os.getenv('TAP_SQUARE_PROD_APPLICATION_SECRET'),
+            'client_id': os.getenv('TAP_SQUARE_APPLICATION_ID'),
+            'client_secret': os.getenv('TAP_SQUARE_APPLICATION_SECRET'),
             'sandbox' : 'true' if env  == 'sandbox' else 'false',
         }
 


### PR DESCRIPTION
# Description of change
The square prod credentials are meant to be used for actual production use cases. The "production" Square account depends on the authorization URL used in the OAuth flow, and will be encoded in the refresh token.

# Manual QA steps
 - N/A, automation should catch this change.
 
# Risks
 - Low, it's tests only
 
# Rollback steps
 - revert this branch
