### PR TITLE
wTesting/data diversity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,6 @@ jobs:
       #      source /usr/local/share/virtualenvs/tap-square/bin/activate
       #      pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init'
       - run:
-          name: 'ALl Tests Running'
-          command: |
-            python tests/test_config.py
-      - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -164,7 +160,13 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_start_date.py
-
+    - run:
+          name: 'All Tests Running'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
+            python tests/test_config.py
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
           name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
-    - run:
+      - run:
+          when: always
           name: 'All Tests Running'
           command: |
             source dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,13 @@ jobs:
           name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+    - run:
+          name: 'All Tests Running'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
+            python tests/test_config.py
       - run:
           when: always
           name: 'Testing Discovery'
@@ -160,13 +167,6 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_start_date.py
-    - run:
-          name: 'All Tests Running'
-          command: |
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
-            python tests/test_config.py
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,20 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_start_date.py
+      - run:
+          when: always
+          name: 'Testing Payments Stream'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests/test_payments.py
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,20 +156,6 @@ jobs:
                      tests/test_pagination.py
       - run:
           when: always
-          name: 'Testing Start Date'
-          command: |
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
-            run-test --tap=tap-square \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_start_date.py
-      - run:
-          when: always
           name: 'Testing Payments Stream'
           command: |
             source dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
       #      source /usr/local/share/virtualenvs/tap-square/bin/activate
       #      pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module'
       - run:
+          name: 'ALl Tests Running'
+          command: |
+            python tests/test_config.py
+      - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -132,6 +136,20 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_pagination.py
+      - run:
+          when: always
+          name: 'Testing Start Date'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests/test_start_date.py
 
 workflows:
   version: 2

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -19,27 +19,27 @@ if __name__ == "__main__":
 
     # CHANGE FLAGS HERE TO TEST SPECIFIC FUNCTION TYPES
     test_creates = True
-    test_updates = True  # To test updates, must also test creates
-    test_gets = True
-    test_deletes = False  # To test updates, must also test creates
+    test_updates = False  # To test updates, must also test creates
+    test_gets = False
+    test_deletes = True  # To test deletes, must also test creates
 
     # CHANGE FLAG TO PRINT ALL OBJECTS THAT FUNCTIONS INTERACT WITH
     print_objects = True
 
-    objects_to_test = [ # CHANGE TO TEST DESIRED STREAMS 
-        # 'modifier_lists', # GET - DONE | CREATE -  | UPDATE -  | DELETE - NA
-        # 'inventories', # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'items',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'categories',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'discounts',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'taxes',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'roles',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
-        # 'employees',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - NA
+    objects_to_test = [ # CHANGE TO TEST DESIRED STREAMS
+        # 'modifier_lists', # GET - DONE | CREATE -  | UPDATE -  | DELETE -
+        # 'inventories', # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
+        # 'items',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
+        'categories',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE - DONE
+        # 'discounts',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
+        # 'taxes',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
+        # 'roles',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
+        # 'employees',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'locations',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'payments',  # GET - DONE | CREATE - DONE | UPDATE - DONE | DELETE -
         # 'refunds',  # GET - DONE | CREATE - DONE | UPDATE - NA  | DELETE -
-        # 'orders'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
-        'shifts'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE - NA
+        # 'orders'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE -
+        # 'shifts'  # GET - DONE | CREATE - DONE | UPDATE - DONE  | DELETE -
     ]
     print("********** Testing basic functions of test client **********")
     if test_gets:

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -74,7 +74,8 @@ if __name__ == "__main__":
                     # import pdb; pdb.set_trace() # UNCOMMENT TO RUN 'INTERACTIVELY'
                     obj_id = created_obj[0].get('id')
                     version = created_obj[0].get('version')
-                    updated_obj = client.update(stream=obj, obj_id=obj_id, version=version, obj=created_obj[0])
+                    updated_obj = client.update(stream=obj, obj_id=obj_id, version=version,
+                                                obj=created_obj[0], start_date=START_DATE)
                     if updated_obj:
                         print("SUCCESS")
                         if print_objects:

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -96,11 +96,10 @@ class TestAutomaticFields(TestSquareBase, TestCase):
         for cat in found_catalogs:
             catalog_entry = menagerie.get_annotated_schema(conn_id, cat['stream_id'])
 
-            # Verify that pks, rep keys, foreign keys have inclusion of automatic (metadata and annotated schema).
+            # Verify that pks and rep keys have inclusion of automatic (metadata and annotated schema).
             for k in self.expected_automatic_fields().get(cat['stream_name']):
                 mdata = next((m for m in catalog_entry['metadata']
                               if len(m['breadcrumb']) == 2 and m['breadcrumb'][1] == k), None)
-
                 print("Validating inclusion on {}: {}".format(cat['stream_name'], mdata))
                 self.assertTrue(mdata and mdata['metadata']['inclusion'] == 'automatic')
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -178,7 +178,7 @@ class TestSquareIncrementalReplication(TestSquareBase, unittest.TestCase):
             else:
                 for message in first_sync_records.get(stream).get('messages'):
                     data = message.get('data')
-                    if not data['is_deleted']:
+                    if not data.get('is_deleted'):
                         first_rec = message.get('data')
                         break
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -202,7 +202,7 @@ class TestSquareIncrementalReplication(TestSquareBase, unittest.TestCase):
             first_rec_id = first_rec.get('id')
             first_rec_version = first_rec.get('version')
 
-            updated_record = self.client.update('payments', first_rec_id, first_rec_version)
+            updated_record = self.client.update('payments', first_rec_id, first_rec_version, self.START_DATE)
             assert len(updated_record) > 0, "Failed to update a {} record".format('payments')
             assert len(updated_record) == 1, "Updated too many {} records".format('payments')
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -179,7 +179,8 @@ class TestSquareIncrementalReplication(TestSquareBase, unittest.TestCase):
                 first_rec = first_sync_records.get(stream).get('messages')[0].get('data')
             first_rec_id = first_rec.get('id')
             first_rec_version = first_rec.get('version')
-            updated_record = self.client.update(stream, obj_id=first_rec_id, version=first_rec_version, obj=first_rec)
+            updated_record = self.client.update(stream, obj_id=first_rec_id, version=first_rec_version,
+                                                obj=first_rec, start_date=self.START_DATE)
             assert len(updated_record) > 0, "Failed to update a {} record".format(stream)
 
             assert len(updated_record) == 1, "Updated too many {} records".format(stream)
@@ -202,7 +203,7 @@ class TestSquareIncrementalReplication(TestSquareBase, unittest.TestCase):
             first_rec_id = first_rec.get('id')
             first_rec_version = first_rec.get('version')
 
-            updated_record = self.client.update('payments', first_rec_id, first_rec_version, self.START_DATE)
+            updated_record = self.client.update('payments', first_rec_id, first_rec_version)
             assert len(updated_record) > 0, "Failed to update a {} record".format('payments')
             assert len(updated_record) == 1, "Updated too many {} records".format('payments')
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -176,7 +176,14 @@ class TestSquareIncrementalReplication(TestSquareBase, unittest.TestCase):
                 if not first_rec:
                     raise RuntimeError("Unable to find any any orders with state other than COMPLETED")
             else:
-                first_rec = first_sync_records.get(stream).get('messages')[0].get('data')
+                for message in first_sync_records.get(stream).get('messages'):
+                    data = message.get('data')
+                    if not data['is_deleted']:
+                        first_rec = message.get('data')
+                        break
+
+                if not first_rec:
+                    raise RuntimeError("Unable to find any {} that were not deleted.".format(stream))
 
             if stream == 'inventories': # This is an append only stream, we will make multiple 'updates'
                 first_rec_catalog_obj_id = first_rec.get('catalog_object_id')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,12 +203,13 @@ class TestClient(SquareClient):
             LOGGER.debug('Created %s with id %s and name %s', catalog_type, catalog_id, catalog_name)
         return resp
 
-    def cleanup(self, stream):
+    def cleanup(self, stream_name):
+        streams = {'CATEGORY': 'categories'}
         three_days_ago = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=3), '%Y-%m-%dT%H:%M:%SZ')
-        catalog = self.get_all(stream, start_date=three_days_ago)
+        catalog = self.get_all(streams.get(stream_name), start_date=three_days_ago)
         catalog_ids = [cat.get('id') for cat in catalog]
 
-        LOGGER.info('Cleaning up %s %s records', len(catalog_ids), stream)
+        LOGGER.info('Cleaning up %s %s records', len(catalog_ids), stream_name)
         self.delete_catalog(catalog_ids)
 
     def post_order(self, body, business_location_id):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,7 +205,7 @@ class TestClient(SquareClient):
 
     def cleanup(self, stream):
         three_days_ago = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=3), '%Y-%m-%dT%H:%M:%SZ')
-        catalog = self.get_all(strem, start_date=three_days_ago)
+        catalog = self.get_all(stream, start_date=three_days_ago)
         catalog_ids = [cat.get('id') for cat in catalog]
 
         LOGGER.info('Cleaning up %s %s records', len(catalog_ids), stream)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,8 +203,8 @@ class TestClient(SquareClient):
             LOGGER.debug('Created %s with id %s and name %s', catalog_type, catalog_id, catalog_name)
         return resp
 
-    def cleanup(self, stream_name, days=3):
-        """Delete the last 3 days worth of data or however many days are necessary."""
+    def cleanup(self, stream_name, days=4):
+        """Delete the last 4 days worth of data or however many days are necessary."""
         streams = {'CATEGORY': 'categories'}
         days_ago = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=days), '%Y-%m-%dT%H:%M:%SZ')
         catalog = self.get_all(streams.get(stream_name), start_date=days_ago)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -873,7 +873,7 @@ class TestClient(SquareClient):
 
         if not action:
             action = random.choice(list(self.PAYMENT_ACTION_TO_STATUS.keys()))
-            
+
         print("PAYMENT UPDATE: status for payment {} change to {} ".format(obj_id, action))
         if action == 'cancel':
             response = self._client.payments.cancel_payment(obj_id)
@@ -1043,6 +1043,16 @@ class TestClient(SquareClient):
     ##########################################################################
 
     def delete_catalog(self, ids_to_delete):
+        LOGGER.info('Attempting batched delete of %s objects', len(ids_to_delete))
+
+        if len(ids_to_delete) > 200:
+            for chunk in chunks(ids_to_delete, 150)
+                body = {'object_ids': chunk}
+                resp = self._client.catalog.batch_delete_catalog_objects(body)
+                if resp.is_error():
+                    raise RuntimeError(resp.errors)
+                return resp.body
+
         body = {'object_ids': ids_to_delete}
         resp = self._client.catalog.batch_delete_catalog_objects(body)
         if resp.is_error():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1046,7 +1046,7 @@ class TestClient(SquareClient):
         LOGGER.info('Attempting batched delete of %s objects', len(ids_to_delete))
 
         if len(ids_to_delete) > 200:
-            for chunk in chunks(ids_to_delete, 150)
+            for chunk in chunks(ids_to_delete, 150):
                 body = {'object_ids': chunk}
                 resp = self._client.catalog.batch_delete_catalog_objects(body)
                 if resp.is_error():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,10 +203,11 @@ class TestClient(SquareClient):
             LOGGER.debug('Created %s with id %s and name %s', catalog_type, catalog_id, catalog_name)
         return resp
 
-    def cleanup(self, stream_name):
+    def cleanup(self, stream_name, days=3):
+        """Delete the last 3 days worth of data or however many days are necessary."""
         streams = {'CATEGORY': 'categories'}
-        three_days_ago = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=3), '%Y-%m-%dT%H:%M:%SZ')
-        catalog = self.get_all(streams.get(stream_name), start_date=three_days_ago)
+        days_ago = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=days), '%Y-%m-%dT%H:%M:%SZ')
+        catalog = self.get_all(streams.get(stream_name), start_date=days_ago)
         catalog_ids = [cat.get('id') for cat in catalog]
 
         LOGGER.info('Cleaning up %s %s records', len(catalog_ids), stream_name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import os.path
 
 # Read in the filenames of the tests/ directroy
 cwd = os.getcwd()
+print("cwd: {}".format(cwd))
 files = [
     name for name in os.listdir('../tap-square/tests/')
     if 'test' == name[:4] and '.py' == name[-3:] and \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import os
+import re
+import os.path
+
+# Read in the filenames of the tests/ directroy
+cwd = os.getcwd()
+files = [
+    name for name in os.listdir('../tap-square/tests/')
+    if 'test' == name[:4] and '.py' == name[-3:] and \
+    name not in ['test_client.py', 'test_config.py']
+]
+
+# Read in the circle config
+with open("../tap-square/.circleci/config.yml", "r") as config:
+    contents = config.read()
+runs = contents.replace(' ', '').replace('\n', '').split('-run:') # separate into run blocks
+
+# Check that each file in the directory can be found in a run black in the circle config
+matches = {f: False for f in files}
+for m in matches.keys():
+    if any([m in run for run in runs]):
+        matches[m] = True
+
+# Verify all files were found
+if all(matches.values()):
+    print("\t SUCCESS: All tests are running in circle.")
+else:
+    raise NotImplementedError("The following tests are not running in circle:\t{}".format([k for k, v in matches.items() if not v]))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,10 @@ import re
 import os.path
 
 # Read in the filenames of the tests/ directroy
-cwd = os.getcwd()
-print("cwd: {}".format(cwd))
+# cwd = os.getcwd()
+# print("cwd: {}".format(cwd))
 files = [
-    name for name in os.listdir('../tap-square/tests/')
+    name for name in os.listdir('/tap-square/tests/')
     if 'test' == name[:4] and '.py' == name[-3:] and \
     name not in ['test_client.py', 'test_config.py']
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import re
 import os.path
 
 # Read in the filenames of the tests/ directroy
+cwd = os.getcwd()
 files = [
     name for name in os.listdir(cwd + '/tests')
     if 'test' == name[:4] and '.py' == name[-3:] and \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,28 +1,32 @@
 import os
-import re
-import os.path
 
-# Read in the filenames of the tests/ directroy
+
 cwd = os.getcwd()
+if cwd not in {'root/project', '/opt/code/tap-square'}:
+    print("WARN: This script is meant to run from the top level directory of the tap.")
+
+print("Reading in filenames from tests directory.")
+print("Parsing directory for tests.")
 files = [
     name for name in os.listdir(cwd + '/tests')
-    if 'test' == name[:4] and '.py' == name[-3:] and \
-    name not in ['test_client.py', 'test_config.py']
+    if 'test' == name[:4] and \  # starts with 'test'
+    '.py' == name[-3:] and \  # is a python file
+    name not in ['test_client.py', 'test_config.py']  # is not this test or the test_client
 ]
 
-# Read in the circle config
+print("Reading contents of circle config")
 with open(cwd + "/.circleci/config.yml", "r") as config:
     contents = config.read()
-runs = contents.replace(' ', '').replace('\n', '').split('-run:') # separate into run blocks
 
 # Check that each file in the directory can be found in a run black in the circle config
+print("Parsing circle config for run blocks.")
+runs = contents.replace(' ', '').replace('\n', '').split('-run:') # separate into run blocks
 matches = {f: False for f in files}
 for m in matches.keys():
+    print("Verifying {} is running in circle.".format(m))
     if any([m in run for run in runs]):
         matches[m] = True
 
 # Verify all files were found
-if all(matches.values()):
-    print("\t SUCCESS: All tests are running in circle.")
-else:
-    raise NotImplementedError("The following tests are not running in circle:\t{}".format([k for k, v in matches.items() if not v]))
+assert all(matches.values()), "The following tests are not running in circle:\t{}".format([k for k, v in matches.items() if not v])
+print("\t SUCCESS: All tests are running in circle.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,8 @@ import re
 import os.path
 
 # Read in the filenames of the tests/ directroy
-# cwd = os.getcwd()
-# print("cwd: {}".format(cwd))
+cwd = os.getcwd()
+print("contents of cwd: {}".format(os.listdir(cwd))
 files = [
     name for name in os.listdir('/tap-square/tests/')
     if 'test' == name[:4] and '.py' == name[-3:] and \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,18 +3,14 @@ import re
 import os.path
 
 # Read in the filenames of the tests/ directroy
-cwd = os.getcwd()
-print("contents of cwd: {}".format(os.listdir(cwd)))
-print("contents of tests: {}".format(os.listdir(cwd + '/tests')))
-print("contents of tap-square: {}".format(os.listdir(cwd + '/tap-square')))
 files = [
-    name for name in os.listdir('/tap-square/tests/')
+    name for name in os.listdir(cwd + '/tests')
     if 'test' == name[:4] and '.py' == name[-3:] and \
     name not in ['test_client.py', 'test_config.py']
 ]
 
 # Read in the circle config
-with open("../tap-square/.circleci/config.yml", "r") as config:
+with open(cwd + "/.circleci/config.yml", "r") as config:
     contents = config.read()
 runs = contents.replace(' ', '').replace('\n', '').split('-run:') # separate into run blocks
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,9 +9,8 @@ print("Reading in filenames from tests directory.")
 print("Parsing directory for tests.")
 files = [
     name for name in os.listdir(cwd + '/tests')
-    if 'test' == name[:4] and \  # starts with 'test'
-    '.py' == name[-3:] and \  # is a python file
-    name not in ['test_client.py', 'test_config.py']  # is not this test or the test_client
+    if 'test' == name[:4] and '.py' == name[-3:] and \
+    name not in ['test_client.py', 'test_config.py']
 ]
 
 print("Reading contents of circle config")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,8 @@ import os.path
 # Read in the filenames of the tests/ directroy
 cwd = os.getcwd()
 print("contents of cwd: {}".format(os.listdir(cwd)))
+print("contents of tests: {}".format(os.listdir(cwd + '/tests')))
+print("contents of tap-square: {}".format(os.listdir(cwd + '/tap-square')))
 files = [
     name for name in os.listdir('/tap-square/tests/')
     if 'test' == name[:4] and '.py' == name[-3:] and \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ files = [
     if 'test' == name[:4] and '.py' == name[-3:] and \
     name not in ['test_client.py', 'test_config.py']
 ]
+print("\tFiles found: {}".format(files))
 
 print("Reading contents of circle config")
 with open(cwd + "/.circleci/config.yml", "r") as config:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import os.path
 
 # Read in the filenames of the tests/ directroy
 cwd = os.getcwd()
-print("contents of cwd: {}".format(os.listdir(cwd))
+print("contents of cwd: {}".format(os.listdir(cwd)))
 files = [
     name for name in os.listdir('/tap-square/tests/')
     if 'test' == name[:4] and '.py' == name[-3:] and \

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -44,6 +44,16 @@ class TestSquarePagination(TestSquareBase, TestCase):
             'locations',  # This stream does not paginate in the sync (See Above)
         })
 
+    def cleanup_excess(self):
+        cleanup = {'categories': 10000}
+        for stream, limit in cleanup.items():
+            print("Checking if cleanup is required.")
+            all_records = self.get_all(stream, start_date=self.STATIC_START_DATE)
+            if len(all_records) > limit / 2:
+                chunk = limit / 4
+                print("Cleaning up {} excess records".format(chunk))
+                self.delete_catalog(all_records[:chunk-1])
+
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
         print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
@@ -69,6 +79,7 @@ class TestSquarePagination(TestSquareBase, TestCase):
         self.assertEqual(set(), self.TESTABLE_STREAMS,
                          msg="Testable streams exist for this category.")
         print("\tThere are no testable streams.")
+        self.cleanup_excess()
 
     def pagination_test(self):
         """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -44,15 +44,18 @@ class TestSquarePagination(TestSquareBase, TestCase):
             'locations',  # This stream does not paginate in the sync (See Above)
         })
 
-    def cleanup_excess(self):
+    @classmethod
+    def tearDownClass(cls):
+        cls.set_environment(cls, cls.SANDBOX)
         cleanup = {'categories': 10000}
         for stream, limit in cleanup.items():
             print("Checking if cleanup is required.")
-            all_records = self.client.get_all(stream, start_date=self.STATIC_START_DATE)
-            if len(all_records) > limit / 2:
-                chunk = limit / 4
+            all_records = cls.client.get_all(stream, start_date=cls.STATIC_START_DATE)
+            all_ids = [rec.get('id') for rec in all_records]
+            if len(all_ids) > limit / 2:
+                chunk = int(limit / 4)
                 print("Cleaning up {} excess records".format(chunk))
-                self.delete_catalog(all_records[:chunk-1])
+                cls.client.delete_catalog(all_ids[:chunk])
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
@@ -79,7 +82,6 @@ class TestSquarePagination(TestSquareBase, TestCase):
         self.assertEqual(set(), self.TESTABLE_STREAMS,
                          msg="Testable streams exist for this category.")
         print("\tThere are no testable streams.")
-        self.cleanup_excess()
 
     def pagination_test(self):
         """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -48,7 +48,7 @@ class TestSquarePagination(TestSquareBase, TestCase):
         cleanup = {'categories': 10000}
         for stream, limit in cleanup.items():
             print("Checking if cleanup is required.")
-            all_records = self.get_all(stream, start_date=self.STATIC_START_DATE)
+            all_records = self.client.get_all(stream, start_date=self.STATIC_START_DATE)
             if len(all_records) > limit / 2:
                 chunk = limit / 4
                 print("Cleaning up {} excess records".format(chunk))

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -114,16 +114,6 @@ class TestSquarePayments(TestSquareBase, TestCase):
         )
         updated_records[stream][updated_desc] = canceled_payment
 
-        # Submit a dispute for a completed payment
-        # desc = "complete"
-        # updated_desc = "dispute"
-        # obj = updated_records[stream][desc]
-        # import pdb; pdb.set_trace()
-        # dispute_payment = self.ensure_dict_object(
-        #     self.client._update_payment(obj.get('id'), obj=obj, action=updated_desc)
-        # )
-        # updated_records[stream][updated_desc] = canceled_payment
-
         # Track all fields from the updated records
         for desc, record in updated_records[stream].items():
             if set(record.keys()).difference(fields):

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+
+from unittest import TestCase
 
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
@@ -8,11 +9,17 @@ import tap_tester.runner      as runner
 from base import TestSquareBase
 
 
-class TestSquarePayments(TestSquareBase):
+class TestSquarePayments(TestSquareBase, TestCase):
     """Test specific data input results in the expected output in the target"""
 
     def name(self):
         return "tap_tester_square_payments"
+
+    def testable_streams_dynamic(self):
+        return self.dynamic_data_streams().difference(self.untestable_streams())
+
+    def testable_streams_static(self):
+        return self.static_data_streams().difference(self.untestable_streams())
 
     def tested_stream(self):
         return 'payments'
@@ -107,6 +114,16 @@ class TestSquarePayments(TestSquareBase):
         )
         updated_records[stream][updated_desc] = canceled_payment
 
+        # Submit a dispute for a completed payment
+        # desc = "complete"
+        # updated_desc = "dispute"
+        # obj = updated_records[stream][desc]
+        # import pdb; pdb.set_trace()
+        # dispute_payment = self.ensure_dict_object(
+        #     self.client._update_payment(obj.get('id'), obj=obj, action=updated_desc)
+        # )
+        # updated_records[stream][updated_desc] = canceled_payment
+
         # Track all fields from the updated records
         for desc, record in updated_records[stream].items():
             if set(record.keys()).difference(fields):
@@ -116,7 +133,6 @@ class TestSquarePayments(TestSquareBase):
 
         # Verify all the fields found in the created and updated records are accounted for by the schema
         schema_keys = set(self.expected_schema_keys(stream))
-        fields.add("blueberry_pie")
         self.assertTrue(fields.issubset(schema_keys),
                         msg="Fields missing from schema: {}".format(fields.difference(schema_keys)))
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,125 @@
+import os
+import unittest
+
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+
+from base import TestSquareBase
+
+
+class TestSquarePayments(TestSquareBase):
+    """Test specific data input results in the expected output in the target"""
+
+    def name(self):
+        return "tap_tester_square_payments"
+
+    def tested_stream(self):
+        return 'payments'
+
+    @classmethod
+    def tearDownClass(cls):
+        print("\n\nTEST TEARDOWN\n\n")
+
+    def ensure_dict_object(self, resp_object):
+        if isinstance(resp_object, dict):
+            return resp_object
+        elif isinstance(resp_object, list):
+            self.assertEqual(1, len(resp_object),
+                             msg="Multiple objects were returned, but only 1 was expected")
+            self.assertTrue(isinstance(resp_object[0], dict),
+                            msg="Response object is a list of {} types".format(type(resp_object[0])))
+            return resp_object[0]
+        else:
+            raise RuntimeError("Type {} was unexpected.\nRecord: {} ".format(type(resp_object), resp_object))
+
+    def test_run(self):
+        """
+        Verify that for payments stream you can get data.
+        """
+        stream = self.tested_stream()
+        self.START_DATE = self.get_properties().get('start_date')
+
+        # Generate various records for the tested stream
+        created_records = {stream: dict()}
+
+        # Create a payment using a card
+        desc = "card"
+        card_payment = self.ensure_dict_object(
+            self.client._create_payment(source_key=desc)
+        )
+        created_records[stream][desc] = card_payment
+
+        # Create a payment using a card on file
+        desc = "card_on_file"
+        card_on_file_payment = self.ensure_dict_object(
+            self.client._create_payment(source_key=desc)
+        )
+        created_records[stream][desc] = card_on_file_payment
+
+        # Create a payment using a gift card
+        desc = "gift_card"
+        gift_card_payment = self.ensure_dict_object(
+            self.client._create_payment(source_key=desc)
+        )
+        created_records[stream][desc] = gift_card_payment
+
+        # Create a payment that will autocomplete
+        desc = "autocomplete"
+        autocomplete_payment = self.ensure_dict_object(
+            self.client._create_payment(autocomplete=True, source_key='card')
+        )
+        created_records[stream][desc] = autocomplete_payment
+
+        # Track all fields from created records
+        fields = set()
+        for desc, record in created_records[stream].items():
+            print("\n\nNew fields found: create of a {} {}".format(desc, stream))
+            if set(record.keys()).difference(fields):
+                print("Adding untracked fields to tracked set: {}\n\n".format(set(record.keys()).difference(fields)))
+            fields.update(record.keys())
+            
+        # Update the records above
+        updated_records = {stream: dict()}
+
+        # Update a completed payment by making a refund (payments must have a status of 'COMPLETED' to process a  )
+        created_desc = "autocomplete"
+        updated_desc = "refund"
+        card_refund, refunded_payment = self.client.create_refund(self.START_DATE, created_records[stream][created_desc])
+        refunded_payment = self.ensure_dict_object(refunded_payment)
+        updated_records[stream][updated_desc] = refunded_payment
+
+        # Update a payment by completing it
+        created_desc = "card_on_file"
+        updated_desc = "complete"
+        obj = created_records[stream][created_desc]
+        completed_payment = self.ensure_dict_object(
+            self.client._update_payment(obj.get('id'), obj=obj, action=updated_desc)
+        )
+        updated_records[stream][updated_desc] = completed_payment
+
+        # Update a payment by canceling it
+        created_desc = "gift_card"
+        updated_desc = "cancel"
+        obj = created_records[stream][created_desc]
+        canceled_payment = self.ensure_dict_object(
+            self.client._update_payment(obj.get('id'), obj=obj, action=updated_desc)
+        )
+        updated_records[stream][updated_desc] = canceled_payment
+
+        # Track all fields from the updated records
+        for desc, record in updated_records[stream].items():
+            if set(record.keys()).difference(fields):
+                print("\n\nNew fields found: update on a {} {}".format(desc, stream))
+                print("Adding untracked fields to tracked set: {}\n\n".format(set(record.keys()).difference(fields)))
+            fields.update(record.keys())
+
+        # Verify all the fields found in the created and updated records are accounted for by the schema
+        schema_keys = set(self.expected_schema_keys(stream))
+        fields.add("blueberry_pie")
+        self.assertTrue(fields.issubset(schema_keys),
+                        msg="Fields missing from schema: {}".format(fields.difference(schema_keys)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description of change
Add explicit data manipulation to bookmarks test for `inventories`.
Add cleanup to pagination test for `categories`.
Add emergency cleanup to handle the apparent 10000 record limit for catalog streams.
Add a test to ensure all tap-tester tests are running in circleci.
Add `test_payments.py` which ensures we are catching all possible fields for the `payments` stream (WIP).
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
