### PR TITLE
Cache forever get_all_location_ids for a single tap sync job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
             pip install --upgrade pip
+            pip install --upgrade setuptools
             pip install .[dev]
       - run:
           name: 'pylint tap'

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,12 @@ setup(name='tap-square',
           'singer-python==5.9.0',
           'squareup==5.3.0.20200528',
           'backoff==1.8.0',
+          'methodtools==0.4.2',
       ],
       extras_require={
           'dev': [
               'ipdb==0.11',
-              'pylint==2.5.3'
+              'pylint==2.5.3',
           ]
       },
       entry_points='''

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -117,6 +117,7 @@ class Locations(FullTableStream):
     valid_replication_keys = []
     replication_key = None
 
+    @lru_cache()
     @classmethod
     def get_all_location_ids(cls, client):
         LOGGER.info("Called get_all_location_ids")

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -120,7 +120,6 @@ class Locations(FullTableStream):
     @lru_cache()
     @classmethod
     def get_all_location_ids(cls, client):
-        LOGGER.info("Called get_all_location_ids")
         all_location_ids = list()
         for page, _ in client.get_locations():
             for location in page:


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SRCE-3745

# Manual QA steps
 - Ran test_sync_canary with a log message before it was cached and after. Before it was written multiple times for a single sync and after it was only written once.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
