### PR TITLE
Yearly pagination for settlements

### DIFF
--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -330,6 +330,11 @@ class SquareClient():
         start_time_dt = utils.strptime_to_utc(start_time)
         end_time_dt = now
 
+        # Parameter `begin_time` cannot be before 1 Jan 2013 00:00:00Z
+        # Doc: https://developer.squareup.com/reference/square/settlements-api/v1-list-settlements
+        if start_time_dt < utils.strptime_to_utc("2013-01-01T00:00:00Z"):
+            raise Exception("Start Date for Settlements stream cannot come before `2013-01-01T00:00:00Z`, current start_date: {}".format(start_time))
+
         while start_time_dt < now:
             params = {
                 'limit': 200,

--- a/tests/base.py
+++ b/tests/base.py
@@ -604,8 +604,8 @@ class TestSquareBaseParent:
             expected_pks_set = set(expected_pks)
             self.assertEqual(len(expected_pks), len(expected_pks_set), msg="Our expectations contain a duplicate record.")
 
-            # Verify that all expected records and ONLY the expected records were replicated
-            self.assertEqual(expected_pks_set, sync_pks_set)
+            # Verify sync pks have all expected records pks in it
+            self.assertTrue(sync_pks_set.issuperset(expected_pks_set))
 
         def assertParentKeysEqual(self, expected_record, sync_record):
             """Compare the top level keys of an expected record and a sync record."""


### PR DESCRIPTION
# Description of change
Settlements, according to [the API docs](https://developer.squareup.com/reference/square/settlements-api/v1-list-settlements) cannot sync more than a year range at a time.

This PR adds date window pagination if the start_date is set to > 1 year ago.

# Manual QA steps
 - Ran through the case where it paginates, and where it doesn't, and examined the date windows used.
 
# Risks
 - Low, it's still as untested (due to data creation restrictions), but this removes an error condition.
 
# Rollback steps
 - revert this branch
