### PR TITLE
Fix/canary test

### DIFF
--- a/tap_square/__init__.py
+++ b/tap_square/__init__.py
@@ -12,7 +12,7 @@ LOGGER = singer.get_logger()
 def main():
     args = singer.utils.parse_args([])
 
-    catalog = args.catalog if args.catalog else discover()
+    catalog = args.catalog if args.catalog else discover(config.get('sandbox'))
 
     if args.discover:
         write_catalog(catalog)

--- a/tap_square/__init__.py
+++ b/tap_square/__init__.py
@@ -12,7 +12,7 @@ LOGGER = singer.get_logger()
 def main():
     args = singer.utils.parse_args([])
 
-    catalog = args.catalog if args.catalog else discover(config.get('sandbox'))
+    catalog = args.catalog if args.catalog else discover(args.config.get('sandbox'))
 
     if args.discover:
         write_catalog(catalog)

--- a/tap_square/__init__.py
+++ b/tap_square/__init__.py
@@ -12,7 +12,10 @@ LOGGER = singer.get_logger()
 def main():
     args = singer.utils.parse_args([])
 
-    catalog = args.catalog if args.catalog else discover(args.config.get('sandbox'))
+    is_sandbox = args.config.get('sandbox')
+    if isinstance(is_sandbox, str):
+        is_sandbox = args.config.get('sandbox') == 'true'
+    catalog = args.catalog if args.catalog else discover(is_sandbox)
 
     if args.discover:
         write_catalog(catalog)

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -25,9 +25,9 @@ def should_not_retry(ex):
     """
     Marks certain exception types (e.g., 400) as non-retryable
     """
-    if (hasattr(ex, "response") and
-        hasattr(ex.response, "status_code") and
-        ex.response.status_code in {400, 401}):
+    if hasattr(ex, "response") and \
+       hasattr(ex.response, "status_code") and \
+       ex.response.status_code in {400, 401}:
         return True
     return False
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -25,9 +25,12 @@ def should_not_retry(ex):
     """
     Marks certain exception types (e.g., 400) as non-retryable
     """
-    if hasattr(ex, "response") and hasattr(ex.response, "status_code") and ex.response.status_code == 400:
+    if (hasattr(ex, "response") and
+        hasattr(ex.response, "status_code") and
+        ex.response.status_code in {400, 401}):
         return True
     return False
+
 
 def log_backoff(details):
     '''
@@ -38,6 +41,7 @@ def log_backoff(details):
 
 class RetryableError(RuntimeError):
     pass
+
 
 class SquareClient():
     def __init__(self, config):

--- a/tap_square/discover.py
+++ b/tap_square/discover.py
@@ -7,13 +7,17 @@ from .streams import STREAMS
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
+# NB: These streams cannot be queried using Sandbox OAuth credentials
+PRODUCTION_ONLY_STREAMS = {'roles', 'bank_accounts', 'settlements'}
 
-def get_schemas():
+def get_schemas(sandbox):
 
     schemas = {}
     schemas_metadata = {}
 
     for stream_name, stream_object in STREAMS.items():
+        if sandbox and stream_name in PRODUCTION_ONLY_STREAMS:
+            continue
 
         schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
         with open(schema_path) as file:
@@ -40,9 +44,9 @@ def get_schemas():
     return schemas, schemas_metadata
 
 
-def discover():
+def discover(sandbox):
 
-    schemas, schemas_metadata = get_schemas()
+    schemas, schemas_metadata = get_schemas(sandbox)
     streams = []
 
     for schema_name, schema in schemas.items():

--- a/tests/base.py
+++ b/tests/base.py
@@ -196,6 +196,8 @@ class TestSquareBaseParent:
             return {
                 'employees',
                 'roles',
+                'bank_accounts',
+                'settlements',
             }
 
         def sandbox_streams(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -107,7 +107,7 @@ class TestSquareBaseParent:
         def expected_metadata(self):
             """The expected streams and metadata about the streams"""
 
-            return {
+            all_streams = {
                 "bank_accounts": {
                     self.PRIMARY_KEYS: {'id'},
                     self.REPLICATION_METHOD: self.FULL,
@@ -183,6 +183,11 @@ class TestSquareBaseParent:
                     self.REPLICATION_KEYS: {'updated_at'}
                 },
             }
+
+            if self.get_environment() == self.SANDBOX:
+                return {k: v for k, v in all_streams.items()
+                        if k not in {'roles', 'bank_accounts', 'settlements'}}
+            return all_streams
 
         def expected_replication_method(self):
             """return a dictionary with key of table name and value of replication method"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -40,6 +40,7 @@ class TestSquareBaseParent:
         START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
         STATIC_START_DATE = "2020-07-13T00:00:00Z"
         START_DATE = ""
+        PRODUCTION_ONLY_STREAMS = {'roles', 'bank_accounts', 'settlements'}
 
         def setUp(self):
             missing_envs = [x for x in [
@@ -186,7 +187,7 @@ class TestSquareBaseParent:
 
             if self.get_environment() == self.SANDBOX:
                 return {k: v for k, v in all_streams.items()
-                        if k not in {'roles', 'bank_accounts', 'settlements'}}
+                        if k not in self.PRODUCTION_ONLY_STREAMS}
             return all_streams
 
         def expected_replication_method(self):

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -10,10 +10,7 @@ class TestSyncCanary(TestSquareBaseParent.TestSquareBase):
         return "tap_tester_sync_canary"
 
     def testable_streams_dynamic(self):
-        return self.dynamic_data_streams().difference({
-            'bank_accounts',
-            'settlements',
-        })
+        return self.dynamic_data_streams()
 
     def testable_streams_static(self):
         return self.static_data_streams()


### PR DESCRIPTION
# Description of change
It aopears that our canary cross multiplication of creds + streams didn't match reality, and sandbox creds cannot be used to query for roles, bank_accounts, or settlements.

This PR keeps `employees` in the set of "production streams" in the tests for the purposes of not being able to create data for them, but also removes streams which cannot be queried with sandbox creds (roles, bank_accounts, settlements) from the sandbox discovery mode.

# Manual QA steps
 - Ran through these situations manually and watched the tests pass/fail
 
# Risks
 - Low, mostly testing and UX oriented.
 
# Rollback steps
 - revert this branch
