### PR TITLE
Add 401 to non-retryable exception codes

### DIFF
--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -25,9 +25,12 @@ def should_not_retry(ex):
     """
     Marks certain exception types (e.g., 400) as non-retryable
     """
-    if hasattr(ex, "response") and hasattr(ex.response, "status_code") and ex.response.status_code == 400:
+    if (hasattr(ex, "response") and
+        hasattr(ex.response, "status_code") and
+        ex.response.status_code in {400, 401}):
         return True
     return False
+
 
 def log_backoff(details):
     '''
@@ -38,6 +41,7 @@ def log_backoff(details):
 
 class RetryableError(RuntimeError):
     pass
+
 
 class SquareClient():
     def __init__(self, config):


### PR DESCRIPTION
# Description of change
401 Unauthorized doesn't make sense to be retried, so this PR removes that status code from the client's retry pattern.

# Manual QA steps
 - Ran through and confirmed that it works.
 
# Risks
 - Low, it's retry in safe code. Worst case it still retries.
 
# Rollback steps
 - revert this branch
