### PR TITLE
Version 0.6.2 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.6.2](https://github.com/singer-io/tap-square/tree/v0.6.2) (2020-06-22)
+
+* Fixes Discovery in Sandbox to ignore streams unavailable in the sandbox
+* Adds pagination to Settlements stream for time ranges over a year
+
+[Full Changelog](https://github.com/singer-io/tap-square/compare/v0.6.0...v0.6.2)
+
+
 ## [v0.6.0](https://github.com/singer-io/tap-square/tree/v0.6.0) (2020-06-22)
 
 [Full Changelog](https://github.com/singer-io/tap-square/compare/v0.4.0...v0.6.0)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-square',
-      version='0.6.1',
+      version='0.6.2',
       description='Singer.io tap for extracting data from the Square API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Bumping version for the latest patch fixes.

# Manual QA steps
 - N/A, accounted for in the member PRs
 
# Risks
 - Low, this is not fully functional yet.
 
# Rollback steps
 - revert to tag 0.6.1 changes, bump patch version to 0.6.3 and re-release
