### PR TITLE
retry refund create on version mismatch

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,17 +773,14 @@ class TestClient():
             refunds += created_refund
         return refunds
 
-    @backoff.on_exception(
-        backoff.expo,
-        RuntimeError,
-        max_tries=3,
+
         jitter=backoff.full_jitter,
         on_backoff=log_backoff,
     )
     @backoff.on_exception(
         backoff.expo,
-        requests.exceptions.RequestException,
-        max_time=120, # seconds
+        (requests.exceptions.RequestException, RuntimeError),
+        max_tries=3,
         jitter=backoff.full_jitter,
         on_backoff=log_backoff,
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,10 +773,6 @@ class TestClient():
             refunds += created_refund
         return refunds
 
-
-        jitter=backoff.full_jitter,
-        on_backoff=log_backoff,
-    )
     @backoff.on_exception(
         backoff.expo,
         (requests.exceptions.RequestException, RuntimeError),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -780,7 +780,7 @@ class TestClient():
         jitter=backoff.full_jitter,
         on_backoff=log_backoff,
     )
-    def create_refund(self, start_date, payment_response=None, retryable=True):
+    def create_refund(self, start_date, payment_response=None):
         """
         Create a refund object. This depends on an exisitng payment record, and will
         act as an UPDATE for a payment record. We can only refund payments whose status is
@@ -815,10 +815,6 @@ class TestClient():
 
         refund = self._client.refunds.refund_payment(body)
         if refund.is_error():
-            if retryable and any([err.get('code') == "VERSION_MISMATCH" for err in refund.errors]):
-                LOGGER.warning("VERSION_MISMATCH Exception Caught: retrying create refund")
-                return self.create_refund(start_date, payment_response=payment_response, retryable=False)
-
             LOGGER.error("body: %s", body)
             LOGGER.error("response: %s", refund)
             LOGGER.error("payment attempted to be refunded: %s", payment_obj)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,6 +773,13 @@ class TestClient():
             refunds += created_refund
         return refunds
 
+    @backoff.on_exception(
+        backoff.expo,
+        requests.exceptions.RequestException,
+        max_tries=3,
+        jitter=backoff.full_jitter,
+        on_backoff=log_backoff,
+    )
     def create_refund(self, start_date, payment_response=None, retryable=True):
         """
         Create a refund object. This depends on an exisitng payment record, and will

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -775,8 +775,15 @@ class TestClient():
 
     @backoff.on_exception(
         backoff.expo,
-        requests.exceptions.RequestException,
+        RuntimeError,
         max_tries=3,
+        jitter=backoff.full_jitter,
+        on_backoff=log_backoff,
+    )
+    @backoff.on_exception(
+        backoff.expo,
+        requests.exceptions.RequestException,
+        max_time=120, # seconds
         jitter=backoff.full_jitter,
         on_backoff=log_backoff,
     )


### PR DESCRIPTION
# Description of change
Tests have failed twice due to a version mismatch in the create refund. Address this failure by retrying the create. If this proves to be ineffective we may have to rethink this method. 
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
