### PR TITLE
Loactions/workaround

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -463,18 +463,17 @@ class TestSquareBaseParent:
 
                     LOGGER.info("Data missing for stream %s, will create %s record(s)", stream, num_records)
                     # WORKAROUND to prevent more locations being created. We currently are at the max(300)
-                    if stream == 'locations':
-                        continue
+                    if stream != 'locations':
 
-                    created_records = self.client.create(stream, start_date=start_date, num_records=num_records)
+                        created_records = self.client.create(stream, start_date=start_date, num_records=num_records)
 
-                    if isinstance(created_records, dict):
-                        stream_to_expected_records[stream].append(created_records)
-                    elif isinstance(created_records, list):
-                        stream_to_expected_records[stream].extend(created_records)
-                        self.assertEqual(num_records, len(created_records))
-                    else:
-                        raise NotImplementedError("created_records unknown type: {}".format(created_records))
+                        if isinstance(created_records, dict):
+                            stream_to_expected_records[stream].append(created_records)
+                        elif isinstance(created_records, list):
+                            stream_to_expected_records[stream].extend(created_records)
+                            self.assertEqual(num_records, len(created_records))
+                        else:
+                            raise NotImplementedError("created_records unknown type: {}".format(created_records))
 
                 print("Adjust expectations for stream: {}".format(stream))
                 self.modify_expected_records(stream_to_expected_records[stream])

--- a/tests/base.py
+++ b/tests/base.py
@@ -451,11 +451,6 @@ class TestSquareBaseParent:
             stream_to_expected_records = {stream: [] for stream in self.expected_streams()}
 
             for stream in create_test_data_streams:
-
-                # WORKAROUND to limit on # of locations permitted. We currently are at the max
-                if stream == 'locations':
-                    continue
-
                 stream_to_expected_records[stream] = self.client.get_all(stream, start_date)
 
                 start_date_key = self.get_start_date_key(stream)
@@ -467,6 +462,10 @@ class TestSquareBaseParent:
                     num_records = max(1, min_required_num_records_per_stream[stream] + 1 - len(stream_to_expected_records[stream]))
 
                     LOGGER.info("Data missing for stream %s, will create %s record(s)", stream, num_records)
+                    # WORKAROUND to prevent more locations being created. We currently are at the max(300)
+                    if stream == 'locations':
+                        continue
+
                     created_records = self.client.create(stream, start_date=start_date, num_records=num_records)
 
                     if isinstance(created_records, dict):

--- a/tests/base.py
+++ b/tests/base.py
@@ -451,6 +451,11 @@ class TestSquareBaseParent:
             stream_to_expected_records = {stream: [] for stream in self.expected_streams()}
 
             for stream in create_test_data_streams:
+
+                # WORKAROUND to limit on # of locations permitted. We currently are at the max
+                if stream == 'locations':
+                    continue
+
                 stream_to_expected_records[stream] = self.client.get_all(stream, start_date)
 
                 start_date_key = self.get_start_date_key(stream)


### PR DESCRIPTION
# Description of change
There is a known issue where a given account can only have 300 objects for the `locations` stream. This was not accounted for in the all_fields_schema test and we have gotten around this by altering the base method to never create a record for locations. 

The other tests were written in a way that assumed no locations would be created, so this should not affect them. This was just an oversight that came up for 1 test.

# Manual QA steps
 - Run test loally
 - Verify we have 300 (max) records
 
# Risks
 - Test change only
 
# Rollback steps
 - revert this branch
