### PR TITLE
Fix birthday, cursor pagination, and state saving

### DIFF
--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -163,25 +163,22 @@ class SquareClient():
             'bank_accounts')
 
     def get_customers(self, start_time, bookmarked_cursor):
-        if bookmarked_cursor:
-            body = {
-                "cursor": bookmarked_cursor,
-                'limit': 100,
-            }
-        else:
-            body = {
-                "query": {
-                    "filter": {
-                        "updated_at": {
-                            "start_at": start_time
-                        }
-                    },
-                    "sort": {
-                        "sort_field": "UPDATED_AT",
-                        "sort_order": "ASC"
+        body = {
+            "query": {
+                "filter": {
+                    "updated_at": {
+                        "start_at": start_time
                     }
+                },
+                "sort": {
+                    "sort_field": "UPDATED_AT",
+                    "sort_order": "ASC"
                 }
             }
+        }
+
+        if bookmarked_cursor:
+            body['cursor'] = bookmarked_cursor
 
         yield from self._get_v2_objects(
             'customers',

--- a/tap_square/schemas/customers.json
+++ b/tap_square/schemas/customers.json
@@ -94,11 +94,21 @@
       ]
     },
     "birthday": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
+      "anyOf": [
+        {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ]
     },
     "email_address": {
       "type": [

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -63,6 +63,7 @@ def sync(config, state, catalog):
                     singer.write_state(state)
 
                 state = singer.clear_bookmark(state, tap_stream_id, 'sync_start')
+                state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
                 state = singer.write_bookmark(
                     state,
                     tap_stream_id,
@@ -98,8 +99,8 @@ def sync(config, state, catalog):
                         transformed_record,
                     )
 
-            state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
-            singer.write_state(state)
+                state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
+                singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)
     singer.write_state(state)

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -87,6 +87,9 @@ def sync(config, state, catalog):
                     state = singer.write_bookmark(state, tap_stream_id, 'cursor', cursor)
                     singer.write_state(state)
 
+                state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
+                state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
+                singer.write_state(state)
             else:
                 for record in stream_obj.sync(start_time, bookmarked_cursor):
                     transformed_record = transformer.transform(record, stream_schema, stream_metadata)
@@ -95,9 +98,6 @@ def sync(config, state, catalog):
                         transformed_record,
                     )
 
-            state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
-            state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
-            singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)
     singer.write_state(state)

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -85,7 +85,6 @@ def sync(config, state, catalog):
                             max_record_value = transformed_record[replication_key]
 
                     state = singer.write_bookmark(state, tap_stream_id, 'cursor', cursor)
-                    state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
                     singer.write_state(state)
 
             else:
@@ -95,7 +94,9 @@ def sync(config, state, catalog):
                         tap_stream_id,
                         transformed_record,
                     )
+
             state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
+            state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
             singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -98,6 +98,8 @@ def sync(config, state, catalog):
                         transformed_record,
                     )
 
+            state = singer.clear_bookmark(state, tap_stream_id, 'cursor')
+            singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)
     singer.write_state(state)


### PR DESCRIPTION
# Description of change

Make the `birthday` field under the `customers` stream accept strings that
do not format to datetimes (ie `0000-12-23T00:00:00Z`)

Fix querying with a cursor to include the previous query. We were
receiving `INVALID_REQUEST_ERROR` because we did not include the
start_date with the query.

Also moved the saving of the `start_date` bookmark to after we clear out
the `cursor` bookmark because we need the previously used `start_date` to
use the cursor.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
