### PR TITLE
Fix circle to stop tap-tester sharing PYTHONPATH with tap-square

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -60,7 +59,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -74,7 +72,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -88,7 +85,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             python tests/test_config.py
       - run:
           when: always
@@ -96,7 +92,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -110,7 +105,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -124,7 +118,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -138,7 +131,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -152,7 +144,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
@@ -166,7 +157,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/ \
             run-test --tap=tap-square \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \

--- a/tap_square/schemas/items.json
+++ b/tap_square/schemas/items.json
@@ -276,6 +276,18 @@
             "string"
           ]
         },
+        "legacy_tax_ids": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
         "tax_ids": {
           "type": [
             "null",

--- a/tap_square/schemas/payments.json
+++ b/tap_square/schemas/payments.json
@@ -326,6 +326,27 @@
         "string"
       ]
     },
+    "risk_evaluation": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "risk_level": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "receipt_url": {
       "type": [
         "null",

--- a/tests/base.py
+++ b/tests/base.py
@@ -645,6 +645,21 @@ class TestSquareBaseParent:
                 self.assertDictEqualWithOffKeys(expected_record, sync_record, {'created_at', 'updated_at'})
             elif stream == 'inventories':
                 self.assertDictEqualWithOffKeys(expected_record, sync_record, {'calculated_at'})
+            elif stream == 'items':
+                self.assertParentKeysEqual(expected_record, sync_record)
+                expected_record_copy = deepcopy(expected_record)
+                sync_record_copy = deepcopy(sync_record)
+
+                # Square api for some reason adds legacy_tax_ids in item_data but not when the item is created. If they are equal to tax_ids (which we compare with the expected record correctly) they're ignored if they are missing only in the expected record
+                if ('item_data' in expected_record and
+                    'item_data' in sync_record and
+                    'legacy_tax_ids' in sync_record['item_data'] and
+                    'legacy_tax_ids' not in expected_record['item_data']):
+                    self.assertIn('tax_ids', sync_record['item_data'])
+                    self.assertEqual(sync_record_copy['item_data'].pop('legacy_tax_ids'),
+                                     sync_record['item_data']['tax_ids'])
+
+                self.assertDictEqual(expected_record_copy, sync_record_copy)
             else:
                 self.assertDictEqual(expected_record, sync_record)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -652,9 +652,9 @@ class TestSquareBaseParent:
 
                 # Square api for some reason adds legacy_tax_ids in item_data but not when the item is created. If they are equal to tax_ids (which we compare with the expected record correctly) they're ignored if they are missing only in the expected record
                 if ('item_data' in expected_record and
-                    'item_data' in sync_record and
-                    'legacy_tax_ids' in sync_record['item_data'] and
-                    'legacy_tax_ids' not in expected_record['item_data']):
+                        'item_data' in sync_record and
+                        'legacy_tax_ids' in sync_record['item_data'] and
+                        'legacy_tax_ids' not in expected_record['item_data']):
                     self.assertIn('tax_ids', sync_record['item_data'])
                     self.assertEqual(sync_record_copy['item_data'].pop('legacy_tax_ids'),
                                      sync_record['item_data']['tax_ids'])

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -61,8 +61,10 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
         self.bookmarks_test(self.testable_streams_dynamic().intersection(self.sandbox_streams()))
 
         self.set_environment(self.PRODUCTION)
-        print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
-        self.bookmarks_test(self.testable_streams_dynamic().intersection(self.production_streams()))
+        production_testable_streams = self.testable_streams_dynamic().intersection(self.production_streams())
+        if production_testable_streams:
+            print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+            self.bookmarks_test(production_testable_streams)
 
     def bookmarks_test(self, testable_streams):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -820,7 +820,7 @@ class TestClient():
             LOGGER.error("payment attempted to be refunded: %s", payment_obj)
             raise RuntimeError(refund.errors)
 
-        completed_refund = self.get_object_matching_conditions('refunds', refund.body.get('refund').get('id'), start_date=start_date, status='COMPLETED')
+        completed_refund = self.get_object_matching_conditions('refunds', refund.body.get('refund').get('id'), start_date=start_date, keys_exist={'processing_fee'}, status='COMPLETED')
         completed_payment = self.get_object_matching_conditions('payments', payment_response.get('id'), start_date=start_date, keys_exist={'processing_fee'}, status='COMPLETED', refunded_money=amount_money)[0]
         return (completed_refund, completed_payment)
 


### PR DESCRIPTION
# Description of change
Circle has been broken for tap-square for 12+ days. It's actually been broken longer but sandbox was broken before then so it's unclear how long this has been a problem. The issue is that the python path sharing in the tests. It should not do that. Each virtualenv should be independent. This change should fix that.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
