### PR TITLE
Refactor sync code into individual stream classes

### DIFF
--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -183,27 +183,25 @@ class SquareClient():
             body,
             'customers')
 
-    def get_orders(self, location_ids, start_time, bookmarked_cursor):
-        if bookmarked_cursor:
-            body = {
-                "cursor": bookmarked_cursor,
-            }
-        else:
-            body = {
-                "query": {
-                    "filter": {
-                        "date_time_filter": {
-                            "updated_at": {
-                                "start_at": start_time
-                            }
+    def get_orders(self, location_ids, start_time, cursor):
+        body = {
+            "query": {
+                "filter": {
+                    "date_time_filter": {
+                        "updated_at": {
+                            "start_at": start_time
                         }
-                    },
-                    "sort": {
-                        "sort_field": "UPDATED_AT",
-                        "sort_order": "ASC"
                     }
+                },
+                "sort": {
+                    "sort_field": "UPDATED_AT",
+                    "sort_order": "ASC"
                 }
             }
+        }
+
+        if cursor:
+            body["cursor"] = cursor,
 
         body['location_ids'] = location_ids
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -201,7 +201,7 @@ class SquareClient():
         }
 
         if cursor:
-            body["cursor"] = cursor,
+            body["cursor"] = cursor
 
         body['location_ids'] = location_ids
 

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -120,6 +120,9 @@ class Employees(FullTableStream):
     valid_replication_keys = []
     replication_key = None
 
+    def get_pages(self, bookmarked_cursor, start_time):
+        raise NotImplementedError("Functionality fully implemented in sync()")
+
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -21,7 +21,10 @@ class CatalogStream(Stream):
     tap_stream_id = None
     replication_key = None
 
-    def sync():
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
+        bookmarked_cursor = singer.get_bookmark(state, tap_stream_id, 'cursor')
+
         max_record_value = start_time
         cursor = None
         for page, cursor in self.client.get_catalog(self.object_type, start_time, bookmarked_cursor):
@@ -36,6 +39,7 @@ class CatalogStream(Stream):
 
             state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
             singer.write_state(state)
+        return state
 
 
 class FullTableStream(Stream):
@@ -48,12 +52,22 @@ class FullTableStream(Stream):
     def get_pages(self, bookmarked_cursor, start_time):
         raise NotImplementedError("Child classes of FullTableStreams require `get_pages` implementation")
 
-    def sync(self, start_time, bookmarked_cursor=None):
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
+        bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
         for page, cursor in self.get_pages(bookmarked_cursor, start_time):
             for record in page:
-                yield record
+                transformed_record = transformer.transform(record, stream_schema, stream_metadata)
+                singer.write_record(
+                    self.tap_stream_id,
+                    transformed_record,
+                )
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+
+        state = singer.clear_bookmark(state, self.tap_stream_id, 'cursor')
+        singer.write_state(state)
+        return state
 
 
 class Items(CatalogStream):
@@ -110,6 +124,7 @@ class Employees(FullTableStream):
                     yield record
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+        return state
 
 
 class ModifierLists(CatalogStream):
@@ -190,7 +205,8 @@ class Orders(Stream):
     replication_key = 'updated_at'
     object_type = 'ORDER'
 
-    def sync():
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
         max_record_value = start_time
         cursor = None
         all_location_ids = Locations.get_all_location_ids(self.client)
@@ -231,7 +247,9 @@ class Shifts(Stream):
     valid_replication_keys = ['updated_at']
     replication_key = 'updated_at'
 
-    def sync(start_time, state, stream_schema, stream_metadata):
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
+
         sync_start_bookmark = singer.get_bookmark(
             state,
             self.tap_stream_id,
@@ -288,6 +306,7 @@ class Roles(FullTableStream):
                     yield record
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+        return state
 
 
 class CashDrawerShifts(FullTableStream):
@@ -325,7 +344,7 @@ class Customers(Stream):
     valid_replication_keys = ['updated_at']
     replication_key = 'updated_at'
 
-    def sync(start_time, state, stream_schema, stream_metadata):
+    def sync(self, start_time, state, stream_schema, stream_metadata):
         cursor = None
         for window_start, window_end in get_date_windows(start_time):
             LOGGER.info("Searching for customers from %s to %s", window_start, window_end)

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -264,7 +264,7 @@ class Shifts(Stream):
             self.tap_stream_id,
             'sync_start',
             singer.utils.strftime(singer.utils.now(),
-                                    format_str=singer.utils.DATETIME_PARSE)
+                                  format_str=singer.utils.DATETIME_PARSE)
         )
         state = singer.write_bookmark(
             state,

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -137,6 +137,10 @@ class Employees(FullTableStream):
                     )
             singer.write_bookmark(state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(state)
+
+        state = singer.clear_bookmark(state, self.tap_stream_id, 'cursor')
+        singer.write_state(state)
+
         return state
 
 
@@ -327,6 +331,11 @@ class Roles(FullTableStream):
                     )
             singer.write_bookmark(state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(state)
+
+
+        state = singer.clear_bookmark(state, self.tap_stream_id, 'cursor')
+        singer.write_state(state)
+
         return state
 
 

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -16,7 +16,7 @@ def sync(config, state, catalog): # pylint: disable=too-many-statements
             stream_schema = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)
 
-            LOGGER.info('Staring sync for stream: %s', tap_stream_id)
+            LOGGER.info('Starting sync for stream: %s', tap_stream_id)
 
             state = singer.set_currently_syncing(state, tap_stream_id)
             singer.write_state(state)

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -43,10 +43,7 @@ def sync(config, state, catalog): # pylint: disable=too-many-statements
             start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
             bookmarked_cursor = singer.get_bookmark(state, tap_stream_id, 'cursor')
 
-            if tap_stream_id == 'shifts':
-                state = stream_obj.sync(start_time, state, stream_schema, stream_metadata)
-
-            elif tap_stream_id == 'customers':
+            if tap_stream_id in ('shifts', 'customers'):
                 state = stream_obj.sync(start_time, state, stream_schema, stream_metadata)
 
             elif stream_obj.replication_method == 'INCREMENTAL':

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -65,8 +65,9 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
         self.set_environment(self.PRODUCTION)
         production_testable_streams = self.testable_streams_dynamic().intersection(self.production_streams())
 
-        print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
-        self.bookmarks_test(production_testable_streams)
+        if production_testable_streams:
+            print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+            self.bookmarks_test(production_testable_streams)
 
     def bookmarks_test(self, testable_streams):
         """


### PR DESCRIPTION
# Description of change
Major refactor to clean up the sync.py code and push the differences into the individualized stream classes
- only minor functional change ( get_orders query) but otherwise just refactoring
- Functional changes coming in subsequent PR

# Manual QA steps
 - Sync canary test passes locally
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
