### PR TITLE
Remove bookmark cursor from incremental streams and test bookmark cursor for every stream using it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: 'pylint tap'
           command: |
             source /usr/local/share/virtualenvs/tap-square/bin/activate
-            pylint tap_square -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring'
+            pylint tap_square -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring,arguments-differ'
       - run:
           name: 'pylint tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'setup virtual env'
+          name: 'Setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -31,7 +31,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-square/bin/activate
             pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring'
       - run:
-          name: 'json validator'
+          name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/tap_square/schemas/*.json
@@ -43,11 +43,11 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'integration tests setup'
+          name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
-          name: 'all tests running'
+          name: 'All Tests Running'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -60,7 +60,7 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'setup virtual env'
+          name: 'Setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -68,11 +68,11 @@ jobs:
             pip install --upgrade setuptools
             pip install .[dev]
       - run:
-          name: 'integration tests setup'
+          name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
-          name: 'test discovery'
+          name: 'Test Discovery'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -80,7 +80,7 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_discovery.py
 
@@ -91,7 +91,7 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'setup virtual env'
+          name: 'Setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -99,11 +99,11 @@ jobs:
             pip install --upgrade setuptools
             pip install .[dev]
       - run:
-          name: 'integration tests setup'
+          name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
-          name: 'testing sync canary'
+          name: 'Testing Sync Canary'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -111,7 +111,7 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_sync_canary.py
 
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'setup virtual env'
+          name: 'Setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -130,11 +130,11 @@ jobs:
             pip install --upgrade setuptools
             pip install .[dev]
       - run:
-          name: 'integration tests setup'
+          name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
-          name: 'testing default start date'
+          name: 'Testing Default Start Date'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -142,7 +142,7 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_default_start_date.py
 
@@ -153,7 +153,7 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'setup virtual env'
+          name: 'Setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -162,12 +162,12 @@ jobs:
             pip install .[dev]
       - run:
           when: always
-          name: 'integration tests setup'
+          name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
           when: always
-          name: 'testing automatic fields'
+          name: 'Testing Automatic Fields'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -175,12 +175,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_automatic_fields.py
       - run:
           when: always
-          name: 'testing schema and all fields'
+          name: 'Testing Schema and All Fields'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -188,12 +188,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_all_fields.py
       - run:
           when: always
-          name: 'testing bookmarks for dynamic data streams'
+          name: 'Testing Bookmarks for Dynamic Data Streams'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -201,12 +201,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_bookmarks.py
       - run:
           when: always
-          name: 'testing bookmarks for static data streams'
+          name: 'Testing Bookmarks for Static Data Streams'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -214,12 +214,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_bookmarks_static.py
       - run:
           when: always
-          name: 'testing start date'
+          name: 'Testing Start Date'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -227,12 +227,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_start_date.py
       - run:
           when: always
-          name: 'testing pagination'
+          name: 'Testing Pagination'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -240,12 +240,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_pagination.py
       - run:
           when: always
-          name: 'testing cursor bookmark'
+          name: 'Testing Cursor Bookmark'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$sandbox_password \
+                     --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_bookmarks_cursor.py
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,19 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests/test_pagination.py
+      - run:
+          when: always
+          name: 'Testing Cursor Bookmark'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests/test_bookmarks_cursor.py
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: 'pylint tap'
           command: |
             source /usr/local/share/virtualenvs/tap-square/bin/activate
-            pylint tap_square -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring,arguments-differ'
+            pylint tap_square -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring'
       - run:
           name: 'pylint tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ jobs:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/deployment-utils:0.latest
     steps:
       - run: deployment_utils queue
-  build:
+  pylint-and-json-validator:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - add_ssh_keys
       - run:
-          name: 'Setup virtual env'
+          name: 'setup virtual env'
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
@@ -31,64 +31,48 @@ jobs:
             source /usr/local/share/virtualenvs/tap-square/bin/activate
             pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring'
       - run:
-          name: 'JSON Validator'
+          name: 'json validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/tap_square/schemas/*.json
+
+  all-integ-tests-running-test:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
       - run:
-          when: always
-          name: 'Integration Tests Setup'
+          name: 'integration tests setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
-          when: always
-          name: 'Test Discovery'
-          command: |
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-square \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_discovery.py
-      - run:
-          when: always
-          name: 'Testing Sync Canary'
-          command: |
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-square \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_sync_canary.py
-      - run:
-          when: always
-          name: 'Testing Default Start Date'
-          command: |
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-square \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_default_start_date.py
-      - run:
-          when: always
-          name: 'All Tests Running'
+          name: 'all tests running'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             python tests/test_config.py
+
+  discovery-test:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
       - run:
-          when: always
-          name: 'Testing Automatic Fields'
+          name: 'setup virtual env'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-square
+            source /usr/local/share/virtualenvs/tap-square/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade setuptools
+            pip install .[dev]
+      - run:
+          name: 'integration tests setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      - run:
+          name: 'test discovery'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -96,12 +80,107 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
+                     --client-id=50 \
+                     tests/test_discovery.py
+
+  sync-canary-test:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
+      - run:
+          name: 'setup virtual env'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-square
+            source /usr/local/share/virtualenvs/tap-square/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade setuptools
+            pip install .[dev]
+      - run:
+          name: 'integration tests setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      - run:
+          name: 'testing sync canary'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$sandbox_password \
+                     --client-id=50 \
+                     tests/test_sync_canary.py
+
+  default-start-date-test:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
+      - run:
+          name: 'setup virtual env'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-square
+            source /usr/local/share/virtualenvs/tap-square/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade setuptools
+            pip install .[dev]
+      - run:
+          name: 'integration tests setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      - run:
+          name: 'testing default start date'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$sandbox_password \
+                     --client-id=50 \
+                     tests/test_default_start_date.py
+
+  non-parallizable-tests:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
+      - run:
+          name: 'setup virtual env'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-square
+            source /usr/local/share/virtualenvs/tap-square/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade setuptools
+            pip install .[dev]
+      - run:
+          when: always
+          name: 'integration tests setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      - run:
+          when: always
+          name: 'testing automatic fields'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-square \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_automatic_fields.py
       - run:
           when: always
-          name: 'Testing Schema and All Fields'
+          name: 'testing schema and all fields'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -109,12 +188,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_all_fields.py
       - run:
           when: always
-          name: 'Testing Bookmarks for Dynamic Data Streams'
+          name: 'testing bookmarks for dynamic data streams'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -122,12 +201,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_bookmarks.py
       - run:
           when: always
-          name: 'Testing Bookmarks for Static Data Streams'
+          name: 'testing bookmarks for static data streams'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -135,12 +214,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_bookmarks_static.py
       - run:
           when: always
-          name: 'Testing Start Date'
+          name: 'testing start date'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -148,12 +227,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_start_date.py
       - run:
           when: always
-          name: 'Testing Pagination'
+          name: 'testing pagination'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -161,12 +240,12 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_pagination.py
       - run:
           when: always
-          name: 'Testing Cursor Bookmark'
+          name: 'testing cursor bookmark'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -174,7 +253,7 @@ jobs:
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \
                      --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
+                     --password=$sandbox_password \
                      --client-id=50 \
                      tests/test_bookmarks_cursor.py
 workflows:
@@ -183,7 +262,27 @@ workflows:
     jobs:
       - queue:
           context: circleci-user
-      - build:
+      - pylint-and-json-validator:
+          context: circleci-user
+          requires:
+            - queue
+      - all-integ-tests-running-test:
+          context: circleci-user
+          requires:
+            - queue
+      - discovery-test:
+          context: circleci-user
+          requires:
+            - queue
+      - sync-canary-test:
+          context: circleci-user
+          requires:
+            - queue
+      - default-start-date-test:
+          context: circleci-user
+          requires:
+            - queue
+      - non-parallizable-tests:
           context: circleci-user
           requires:
             - queue
@@ -196,5 +295,15 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
+      - pylint-and-json-validator:
+          context: circleci-user
+      - all-integ-tests-running-test:
+          context: circleci-user
+      - discovery-test:
+          context: circleci-user
+      - sync-canary-test:
+          context: circleci-user
+      - default-start-date-test:
+          context: circleci-user
+      - non-parallizable-tests:
           context: circleci-user

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
 [MASTER]
 init-hook='import sys; sys.path.append("/opt/code/tap-tester/"); sys.path.append("/code/tap-tester/");'
+
+[MESSAGES CONTROL]
+disable=broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -107,7 +107,7 @@ class SquareClient():
             yield (result.body.get(body_key, []), cursor)
 
 
-    def get_catalog(self, object_type, start_time, bookmarked_cursor):
+    def get_catalog(self, object_type, start_time):
         # Move the max_updated_at back the smallest unit possible
         # because the begin_time query param is exclusive
         start_time = utils.strptime_to_utc(start_time)
@@ -119,10 +119,7 @@ class SquareClient():
             "include_deleted_objects": True,
         }
 
-        if bookmarked_cursor:
-            body['cursor'] = bookmarked_cursor
-        else:
-            body['begin_time'] = start_time
+        body['begin_time'] = start_time
 
         yield from self._get_v2_objects(
             object_type,

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -183,27 +183,25 @@ class SquareClient():
             body,
             'customers')
 
-    def get_orders(self, location_ids, start_time, bookmarked_cursor):
-        if bookmarked_cursor:
-            body = {
-                "cursor": bookmarked_cursor,
-            }
-        else:
-            body = {
-                "query": {
-                    "filter": {
-                        "date_time_filter": {
-                            "updated_at": {
-                                "start_at": start_time
-                            }
+    def get_orders(self, location_ids, start_time, cursor):
+        body = {
+            "query": {
+                "filter": {
+                    "date_time_filter": {
+                        "updated_at": {
+                            "start_at": start_time
                         }
-                    },
-                    "sort": {
-                        "sort_field": "UPDATED_AT",
-                        "sort_order": "ASC"
                     }
+                },
+                "sort": {
+                    "sort_field": "UPDATED_AT",
+                    "sort_order": "ASC"
                 }
             }
+        }
+
+        if cursor:
+            body["cursor"] = cursor,
 
         body['location_ids'] = location_ids
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -101,7 +101,6 @@ class SquareClient():
                 body['cursor'] = cursor
 
             with singer.http_request_timer('GET ' + request_timer_suffix):
-                LOGGER.info("About to call http query with body %s", body)
                 result = self._retryable_v2_method(request_method, body)
 
             cursor = result.body.get('cursor')
@@ -318,7 +317,6 @@ class SquareClient():
                 params['batch_token'] = batch_token
 
             with singer.http_request_timer('GET ' + request_timer_suffix):
-                LOGGER.info("About to call http query with url %s and params %s", url, params)
                 result = self._retryable_v1_method(session, url, params)
 
             batch_token = get_batch_token_from_headers(result.headers)

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -104,7 +104,7 @@ class SquareClient():
             with singer.http_request_timer('GET ' + request_timer_suffix):
                 result = self._retryable_v2_method(request_method, body)
 
-            yield (result.body.get(body_key, []), result.body.get('cursor'))
+            yield result.body.get(body_key, [])
 
             cursor = result.body.get('cursor')
 
@@ -280,7 +280,7 @@ class SquareClient():
                     None,
                 )
 
-            yield (result.body.get('items', []), result.body.get('cursor'))
+            yield result.body.get('items', [])
 
             cursor = result.body.get('cursor')
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -201,7 +201,7 @@ class SquareClient():
         }
 
         if cursor:
-            body["cursor"] = cursor,
+            body["cursor"] = cursor
 
         body['location_ids'] = location_ids
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -39,7 +39,7 @@ def log_backoff(details):
     LOGGER.warning('Error receiving data from square. Sleeping %.1f seconds before trying again', details['wait'])
 
 
-class RetryableError(RuntimeError):
+class RetryableError(Exception):
     pass
 
 

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -162,7 +162,7 @@ class SquareClient():
             body,
             'bank_accounts')
 
-    def get_customers(self, start_time, end_time, cursor):
+    def get_customers(self, start_time, end_time):
         body = {
             "query": {
                 "filter": {
@@ -174,16 +174,13 @@ class SquareClient():
             }
         }
 
-        if cursor is not None:
-            body['cursor'] = cursor
-
         yield from self._get_v2_objects(
             'customers',
             lambda bdy: self._client.customers.search_customers(body=bdy),
             body,
             'customers')
 
-    def get_orders(self, location_ids, start_time, cursor):
+    def get_orders(self, location_ids, start_time):
         body = {
             "query": {
                 "filter": {
@@ -199,9 +196,6 @@ class SquareClient():
                 }
             }
         }
-
-        if cursor:
-            body["cursor"] = cursor
 
         body['location_ids'] = location_ids
 
@@ -223,7 +217,7 @@ class SquareClient():
             body,
             'counts')
 
-    def get_shifts(self):
+    def get_shifts(self, bookmarked_cursor):
         body = {
             "query": {
                 "sort": {
@@ -232,6 +226,9 @@ class SquareClient():
                 }
             }
         }
+
+        if bookmarked_cursor:
+            body['cursor'] = bookmarked_cursor
 
         yield from self._get_v2_objects(
             'shifts',
@@ -247,6 +244,7 @@ class SquareClient():
         body = {
         }
 
+        # TODO Always include body['begin_time'] = start_time
         if bookmarked_cursor:
             body['cursor'] = bookmarked_cursor
         else:
@@ -266,6 +264,7 @@ class SquareClient():
         body = {
         }
 
+        # TODO Always include body['begin_time'] = start_time
         if bookmarked_cursor:
             body['cursor'] = bookmarked_cursor
         else:

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -101,6 +101,7 @@ class SquareClient():
                 body['cursor'] = cursor
 
             with singer.http_request_timer('GET ' + request_timer_suffix):
+                LOGGER.info("About to call http query with body %s", body)
                 result = self._retryable_v2_method(request_method, body)
 
             cursor = result.body.get('cursor')
@@ -321,6 +322,7 @@ class SquareClient():
                 params['batch_token'] = batch_token
 
             with singer.http_request_timer('GET ' + request_timer_suffix):
+                LOGGER.info("About to call http query with url %s and params %s", url, params)
                 result = self._retryable_v1_method(session, url, params)
 
             batch_token = get_batch_token_from_headers(result.headers)

--- a/tap_square/client.py
+++ b/tap_square/client.py
@@ -234,19 +234,17 @@ class SquareClient():
             body,
             'shifts')
 
-    def get_refunds(self, start_time, bookmarked_cursor):  # TODO:check sort_order input
+    def get_refunds(self, start_time, bookmarked_cursor):
         start_time = utils.strptime_to_utc(start_time)
         start_time = start_time - timedelta(milliseconds=1)
         start_time = utils.strftime(start_time)
 
         body = {
         }
+        body['begin_time'] = start_time
 
-        # TODO Always include body['begin_time'] = start_time
         if bookmarked_cursor:
             body['cursor'] = bookmarked_cursor
-        else:
-            body['begin_time'] = start_time
 
         yield from self._get_v2_objects(
             'refunds',
@@ -261,12 +259,10 @@ class SquareClient():
 
         body = {
         }
+        body['begin_time'] = start_time
 
-        # TODO Always include body['begin_time'] = start_time
         if bookmarked_cursor:
             body['cursor'] = bookmarked_cursor
-        else:
-            body['begin_time'] = start_time
 
         yield from self._get_v2_objects(
             'payments',

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -74,7 +74,6 @@ class FullTableStream(Stream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
-        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -140,7 +139,6 @@ class Employees(FullTableStream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = config['start_date']
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
-        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -293,7 +291,6 @@ class Shifts(FullTableStream):
         )
 
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
-        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -333,7 +330,6 @@ class Roles(FullTableStream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = config['start_date']
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
-        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
                 if record['updated_at'] >= start_time:

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -120,6 +120,9 @@ class Employees(FullTableStream):
     valid_replication_keys = []
     replication_key = None
 
+    def get_pages(self, bookmarked_cursor, start_time):
+        raise NotImplementedError("Functionality fully implemented in sync()")
+
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -74,6 +74,7 @@ class FullTableStream(Stream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
+        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -139,6 +140,7 @@ class Employees(FullTableStream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = config['start_date']
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
+        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -291,6 +293,7 @@ class Shifts(FullTableStream):
         )
 
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
+        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
 
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
@@ -330,6 +333,7 @@ class Roles(FullTableStream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = config['start_date']
         bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
+        LOGGER.info("During sync of stream %s found bookmarked_cursor %s", self.tap_stream_id, bookmarked_cursor)
         for page, cursor in self.get_pages_safe(state, bookmarked_cursor, start_time):
             for record in page:
                 if record['updated_at'] >= start_time:

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -21,7 +21,10 @@ class CatalogStream(Stream):
     tap_stream_id = None
     replication_key = None
 
-    def sync():
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
+        bookmarked_cursor = singer.get_bookmark(state, tap_stream_id, 'cursor')
+
         max_record_value = start_time
         cursor = None
         for page, cursor in self.client.get_catalog(self.object_type, start_time, bookmarked_cursor):
@@ -36,6 +39,7 @@ class CatalogStream(Stream):
 
             state = singer.write_bookmark(state, tap_stream_id, replication_key, max_record_value)
             singer.write_state(state)
+        return state
 
 
 class FullTableStream(Stream):
@@ -48,12 +52,22 @@ class FullTableStream(Stream):
     def get_pages(self, bookmarked_cursor, start_time):
         raise NotImplementedError("Child classes of FullTableStreams require `get_pages` implementation")
 
-    def sync(self, start_time, bookmarked_cursor=None):
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
+        bookmarked_cursor = singer.get_bookmark(state, self.tap_stream_id, 'cursor')
         for page, cursor in self.get_pages(bookmarked_cursor, start_time):
             for record in page:
-                yield record
+                transformed_record = transformer.transform(record, stream_schema, stream_metadata)
+                singer.write_record(
+                    self.tap_stream_id,
+                    transformed_record,
+                )
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+
+        state = singer.clear_bookmark(state, self.tap_stream_id, 'cursor')
+        singer.write_state(state)
+        return state
 
 
 class Items(CatalogStream):
@@ -110,6 +124,7 @@ class Employees(FullTableStream):
                     yield record
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+        return state
 
 
 class ModifierLists(CatalogStream):
@@ -190,7 +205,8 @@ class Orders(Stream):
     replication_key = 'updated_at'
     object_type = 'ORDER'
 
-    def sync():
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
         max_record_value = start_time
         cursor = None
         all_location_ids = Locations.get_all_location_ids(self.client)
@@ -231,7 +247,9 @@ class Shifts(Stream):
     valid_replication_keys = ['updated_at']
     replication_key = 'updated_at'
 
-    def sync(start_time, state, stream_schema, stream_metadata):
+    def sync(self, state, stream_schema, stream_metadata, config):
+        start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
+
         sync_start_bookmark = singer.get_bookmark(
             state,
             self.tap_stream_id,
@@ -288,6 +306,7 @@ class Roles(FullTableStream):
                     yield record
             singer.write_bookmark(self.state, self.tap_stream_id, 'cursor', cursor)
             singer.write_state(self.state)
+        return state
 
 
 class CashDrawerShifts(FullTableStream):
@@ -325,7 +344,7 @@ class Customers(Stream):
     valid_replication_keys = ['updated_at']
     replication_key = 'updated_at'
 
-    def sync(start_time, state, stream_schema, stream_metadata):
+    def sync(self, start_time, state, stream_schema, stream_metadata):
         cursor = None
         for window_start, window_end in get_date_windows(start_time):
             LOGGER.info("Searching for customers from %s to %s", window_start, window_end)

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -34,8 +34,7 @@ class CatalogStream(Stream):
     def sync(self, state, stream_schema, stream_metadata, config, transformer):
         start_time = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, config['start_date'])
         max_record_value = start_time
-        cursor = None
-        for page, _ in self.client.get_catalog(self.object_type, start_time, cursor):
+        for page, _ in self.client.get_catalog(self.object_type, start_time):
             for record in page:
                 transformed_record = transformer.transform(record, stream_schema, stream_metadata)
                 singer.write_record(

--- a/tap_square/streams.py
+++ b/tap_square/streams.py
@@ -264,7 +264,7 @@ class Shifts(Stream):
             self.tap_stream_id,
             'sync_start',
             singer.utils.strftime(singer.utils.now(),
-                                    format_str=singer.utils.DATETIME_PARSE)
+                                  format_str=singer.utils.DATETIME_PARSE)
         )
         state = singer.write_bookmark(
             state,

--- a/tap_square/sync.py
+++ b/tap_square/sync.py
@@ -43,10 +43,7 @@ def sync(config, state, catalog): # pylint: disable=too-many-statements
             start_time = singer.get_bookmark(state, tap_stream_id, replication_key, config['start_date'])
             bookmarked_cursor = singer.get_bookmark(state, tap_stream_id, 'cursor')
 
-            if tap_stream_id == 'shifts':
-                state = stream_obj.sync(start_time, state, stream_schema, stream_metadata)
-
-            elif tap_stream_id == 'customers':
+            if tap_stream_id in ('shifts', 'customers'):
                 state = stream_obj.sync(start_time, state, stream_schema, stream_metadata)
 
             elif stream_obj.replication_method == 'INCREMENTAL':

--- a/tests/base.py
+++ b/tests/base.py
@@ -626,10 +626,13 @@ class TestSquareBaseParent:
         ### Standard Assertion Patterns
         ##########################################################################
 
-        def assertPKsEqual(self, stream, expected_records, sync_records):
+        def assertPKsEqual(self, stream, expected_records, sync_records, assert_pk_count_same=False):
             """
             Compare the values of the primary keys for expected and synced records.
             For this comparison to be valid we also check for duplicate primary keys.
+
+            Parameters:
+            arg1 (int): Description of arg1
             """
             primary_keys = list(self.expected_primary_keys().get(stream)) if self.expected_primary_keys().get(stream) else self.makeshift_primary_keys().get(stream)
 
@@ -645,6 +648,9 @@ class TestSquareBaseParent:
 
             # Verify sync pks have all expected records pks in it
             self.assertTrue(sync_pks_set.issuperset(expected_pks_set))
+
+            if assert_pk_count_same:
+                self.assertEqual(expected_pks_set, sync_pks_set)
 
         def assertParentKeysEqual(self, expected_record, sync_record):
             """Compare the top level keys of an expected record and a sync record."""

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,26 +25,6 @@ class DataType(Enum):
 
 class TestSquareBaseParent:
 
-    DEFAULT_BATCH_LIMIT = 1000
-    API_LIMIT = {
-        'items': DEFAULT_BATCH_LIMIT,
-        'inventories': DEFAULT_BATCH_LIMIT,
-        'categories': DEFAULT_BATCH_LIMIT,
-        'discounts': DEFAULT_BATCH_LIMIT,
-        'taxes': DEFAULT_BATCH_LIMIT,
-        'cash_drawer_shifts': DEFAULT_BATCH_LIMIT,
-        'employees': 50,
-        'locations': None, # Api does not accept a cursor and documents no limit, see https://developer.squareup.com/reference/square/locations/list-locations
-        'roles': 100,
-        'refunds': 100,
-        'payments': 100,
-        'customers': 100,
-        'modifier_lists': DEFAULT_BATCH_LIMIT,
-        'orders': 500,
-        'shifts': 200,
-        'settlements': 200,
-    }
-
     # Creating TestSquareBase inside a parent class to avoid
     # unittest trying to run methods in base class starting with 'test'
     class TestSquareBase(ABC, TestCase):
@@ -55,13 +35,32 @@ class TestSquareBaseParent:
         PRIMARY_KEYS = "table-key-properties"
         REPLICATION_METHOD = "forced-replication-method"
         START_DATE_KEY = 'start-date-key'
-        API_LIMIT = "max-row-limit"
         INCREMENTAL = "INCREMENTAL"
         FULL = "FULL_TABLE"
         START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
         STATIC_START_DATE = "2020-07-13T00:00:00Z"
         START_DATE = ""
         PRODUCTION_ONLY_STREAMS = {'roles', 'bank_accounts', 'settlements'}
+
+        DEFAULT_BATCH_LIMIT = 1000
+        API_LIMIT = {
+            'items': DEFAULT_BATCH_LIMIT,
+            'inventories': DEFAULT_BATCH_LIMIT,
+            'categories': DEFAULT_BATCH_LIMIT,
+            'discounts': DEFAULT_BATCH_LIMIT,
+            'taxes': DEFAULT_BATCH_LIMIT,
+            'cash_drawer_shifts': DEFAULT_BATCH_LIMIT,
+            'employees': 50,
+            'locations': None, # Api does not accept a cursor and documents no limit, see https://developer.squareup.com/reference/square/locations/list-locations
+            'roles': 100,
+            'refunds': 100,
+            'payments': 100,
+            'customers': 100,
+            'modifier_lists': DEFAULT_BATCH_LIMIT,
+            'orders': 500,
+            'shifts': 200,
+            'settlements': 200,
+        }
 
         def setUp(self):
             missing_envs = [x for x in [
@@ -471,8 +470,6 @@ class TestSquareBaseParent:
 
             stream_to_expected_records = {stream: [] for stream in self.expected_streams()}
 
-            import ipdb; ipdb.set_trace()
-            1+1
             for stream in create_test_data_streams:
                 stream_to_expected_records[stream] = self.client.get_all(stream, start_date)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,27 @@ class DataType(Enum):
 
 
 class TestSquareBaseParent:
+
+    DEFAULT_BATCH_LIMIT = 1000
+    API_LIMIT = {
+        'items': DEFAULT_BATCH_LIMIT,
+        'inventories': DEFAULT_BATCH_LIMIT,
+        'categories': DEFAULT_BATCH_LIMIT,
+        'discounts': DEFAULT_BATCH_LIMIT,
+        'taxes': DEFAULT_BATCH_LIMIT,
+        'cash_drawer_shifts': DEFAULT_BATCH_LIMIT,
+        'employees': 50,
+        'locations': None, # Api does not accept a cursor and documents no limit, see https://developer.squareup.com/reference/square/locations/list-locations
+        'roles': 100,
+        'refunds': 100,
+        'payments': 100,
+        'customers': 100,
+        'modifier_lists': DEFAULT_BATCH_LIMIT,
+        'orders': 500,
+        'shifts': 200,
+        'settlements': 200,
+    }
+
     # Creating TestSquareBase inside a parent class to avoid
     # unittest trying to run methods in base class starting with 'test'
     class TestSquareBase(ABC, TestCase):
@@ -450,6 +471,8 @@ class TestSquareBaseParent:
 
             stream_to_expected_records = {stream: [] for stream in self.expected_streams()}
 
+            import ipdb; ipdb.set_trace()
+            1+1
             for stream in create_test_data_streams:
                 stream_to_expected_records[stream] = self.client.get_all(stream, start_date)
 
@@ -570,15 +593,16 @@ class TestSquareBaseParent:
                     selected_fields = self.get_selected_fields_from_metadata(catalog_entry['metadata'])
                     self.assertEqual(expected_automatic_fields, selected_fields)
 
-        def run_and_verify_sync(self, conn_id):
+        def run_and_verify_sync(self, conn_id, clear_state=True):
             """
             Clear the connections state in menagerie and Run a Sync.
             Verify the exit code following the sync.
 
             Return the connection id and record count by stream
             """
-            #clear state
-            menagerie.set_state(conn_id, {})
+            if clear_state:
+                #clear state
+                menagerie.set_state(conn_id, {})
 
             # run sync
             sync_job_name = runner.run_sync_mode(self, conn_id)

--- a/tests/base.py
+++ b/tests/base.py
@@ -45,7 +45,7 @@ class TestSquareBaseParent:
         DEFAULT_BATCH_LIMIT = 1000
         API_LIMIT = {
             'items': DEFAULT_BATCH_LIMIT,
-            'inventories': DEFAULT_BATCH_LIMIT,
+            'inventories': 100,
             'categories': DEFAULT_BATCH_LIMIT,
             'discounts': DEFAULT_BATCH_LIMIT,
             'taxes': DEFAULT_BATCH_LIMIT,

--- a/tests/test_bookmarks_cursor.py
+++ b/tests/test_bookmarks_cursor.py
@@ -1,0 +1,153 @@
+import os
+
+import singer
+
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+
+from base import TestSquareBaseParent
+from test_pagination import TestSquarePagination
+
+LOGGER = singer.get_logger()
+
+
+class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase):
+
+    @staticmethod
+    def name():
+        return "tap_tester_square_incremental_replication_cursor"
+
+    def testable_streams_dynamic(self):
+        return {"inventories"}
+        # return self.dynamic_data_streams().intersection(
+        #     self.expected_full_table_streams()).difference(
+        #         self.untestable_streams())
+
+    @staticmethod
+    def testable_streams_static():
+        """ No static streams marked for incremental. """
+        return set()
+
+    @staticmethod
+    def cannot_update_streams():
+        return {
+            'refunds',  # Does not have an endpoint for updating records
+            'modifier_lists',  # Has endpoint but just adds/removes mod_list from an item.
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        print("\n\nTEST TEARDOWN\n\n")
+
+    def run_sync(self, conn_id):
+        """
+        Run a sync job and make sure it exited properly.
+        Return a dictionary with keys of streams synced
+        and values of records synced for each stream
+        """
+        # Run a sync job using orchestrator
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Verify actual rows were synced
+        sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+        return sync_record_count
+
+    def test_run(self):
+        """Instantiate start date according to the desired data set and run the test"""
+
+        self.START_DATE = self.get_properties().get('start_date')
+
+        print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+        self.bookmarks_test(self.testable_streams_dynamic().intersection(self.sandbox_streams()))
+
+        self.set_environment(self.PRODUCTION)
+        production_testable_streams = self.testable_streams_dynamic().intersection(self.production_streams())
+        import ipdb; ipdb.set_trace()
+        1+1
+        if production_testable_streams:
+            print("\n\nTESTING WITH DYNAMIC DATA IN SQUARE_ENVIRONMENT: {}".format(os.getenv('TAP_SQUARE_ENVIRONMENT')))
+            self.bookmarks_test(production_testable_streams)
+
+    def bookmarks_test(self, testable_streams):
+        """
+        Verify for each stream that you can do a sync which records bookmarks.
+        Verify that the bookmark is the max value sent to the target for the `date` PK field
+        Verify that the 2nd sync respects the bookmark
+        Verify that all data of the 2nd sync is >= the bookmark from the first sync
+        Verify that the number of records in the 2nd sync is less then the first
+        Verify inclusivivity of bookmarks
+
+        PREREQUISITE
+        For EACH stream that is incrementally replicated there are multiple rows of data with
+            different values for the replication key
+        """
+        print("\n\nRUNNING {}\n\n".format(self.name()))
+
+        # Ensure tested streams have existing records
+        expected_records_before_removing_first_page = self.create_test_data(testable_streams, self.START_DATE, min_required_num_records_per_stream=self.API_LIMIT)
+        first_page_records, cursor = self.client.get_first_page_and_cursor(testable_streams[0], self.START_DATE)
+        expected_records = [record for record in expected_records_before_removing_first_page
+                            if record not in first_page_records]
+
+        # verify the expected test data exceeds API LIMIT for all testable streams
+        for stream in self.TESTABLE_STREAMS:
+            record_count = len(expected_records[stream])
+            print("Verifying data is sufficient for stream {}. ".format(stream) +
+                  "\tRecord Count: {}\tAPI Limit: {} ".format(record_count, self.API_LIMIT.get(stream)))
+            self.assertGreater(record_count, self.API_LIMIT.get(stream),
+                               msg="Pagination not ensured.\n" +
+                               "{} does not have sufficient data in expecatations.\n ".format(stream))
+
+        # Create connection but do not use default start date
+        conn_id = connections.ensure_connection(self, original_properties=False)
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, found_catalogs, streams_to_select=self.TESTABLE_STREAMS, select_all_fields=True
+        )
+
+        menagerie.set_state(conn_id,
+                            {
+                                "bookmarks": {
+                                    testable_streams[0]: {
+                                        "cursor": cursor
+                                    }
+                                }
+                            })
+
+        # run initial sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id, clear_state=False)
+
+        synced_records = runner.get_records_from_target_output()
+        for stream in self.TESTABLE_STREAMS:
+            with self.subTest(stream=stream):
+                # Verify we are paginating for testable synced streams
+                self.assertGreater(record_count_by_stream.get(stream, -1), self.API_LIMIT.get(stream),
+                                   msg="We didn't guarantee pagination. The number of records should exceed the api limit.")
+
+                data = synced_records.get(stream, [])
+                actual_records = [row['data'] for row in data['messages']]
+                record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
+                auto_fields = self.expected_automatic_fields().get(stream)
+
+                for actual_keys in record_messages_keys:
+
+                    # Verify that the automatic fields are sent to the target for paginated streams
+                    self.assertTrue(auto_fields.issubset(actual_keys),
+                                    msg="A paginated synced stream has a record that is missing automatic fields.")
+
+                    # Verify we have more fields sent to the target than just automatic fields (this is set above)
+                    self.assertEqual(set(), auto_fields.difference(actual_keys),
+                                     msg="A paginated synced stream has a record that is missing expected fields.")
+
+                # Verify by pks that the replicated records match our expectations
+                self.assertPKsEqual(stream, expected_records.get(stream), actual_records)

--- a/tests/test_bookmarks_cursor.py
+++ b/tests/test_bookmarks_cursor.py
@@ -27,7 +27,6 @@ class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase
         # incremental
         all_testable_streams.add('shifts')
 
-        LOGGER.info("testable_streams=%s", all_testable_streams)
         return all_testable_streams
 
     @staticmethod
@@ -103,7 +102,6 @@ class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase
             }
             for testable_stream in testable_streams
         }
-        LOGGER.info("Saving bookmarks to menagerie state %s", bookmarks)
         menagerie.set_state(conn_id, {"bookmarks": bookmarks})
 
         # run initial sync

--- a/tests/test_bookmarks_cursor.py
+++ b/tests/test_bookmarks_cursor.py
@@ -1,5 +1,3 @@
-import os
-
 import singer
 
 import tap_tester.connections as connections
@@ -18,7 +16,7 @@ class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase
         return "tap_tester_square_incremental_replication_cursor"
 
     def testable_streams_dynamic(self):
-        all_testable_streams =  self.dynamic_data_streams().intersection(
+        all_testable_streams = self.dynamic_data_streams().intersection(
             self.expected_full_table_streams()).difference(
                 self.untestable_streams())
 
@@ -105,7 +103,7 @@ class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase
         menagerie.set_state(conn_id, {"bookmarks": bookmarks})
 
         # run initial sync
-        record_count_by_stream = self.run_and_verify_sync(conn_id, clear_state=False)
+        self.run_and_verify_sync(conn_id, clear_state=False)
 
         synced_records = runner.get_records_from_target_output()
         for stream in testable_streams:

--- a/tests/test_bookmarks_cursor.py
+++ b/tests/test_bookmarks_cursor.py
@@ -18,10 +18,10 @@ class TestSquareIncrementalReplicationCursor(TestSquareBaseParent.TestSquareBase
         return "tap_tester_square_incremental_replication_cursor"
 
     def testable_streams_dynamic(self):
-        return {"inventories"}
-        # return self.dynamic_data_streams().intersection(
-        #     self.expected_full_table_streams()).difference(
-        #         self.untestable_streams())
+        # return {"inventories"}
+        return self.dynamic_data_streams().intersection(
+            self.expected_full_table_streams()).difference(
+                self.untestable_streams())
 
     @staticmethod
     def testable_streams_static():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -519,9 +519,24 @@ class TestClient():
             return next(self.get_refunds(start_date, None))
         elif stream == 'inventories':
             return next(self.get_inventories(start_date, None))
+        elif stream == 'payments':
+            return next(self.get_payments(start_date, None))
+        elif stream == 'employees':
+            employees, cursor = next(self.get_roles(None))
+            employees_after_start_date = [
+                role for role in employees
+                if not start_date or role['updated_at'] >= start_date
+            ]
+            return employees_after_start_date, cursor
+        elif stream == 'roles':
+            roles, cursor = next(self.get_roles(None))
+            roles_after_start_date = [
+                role for role in roles
+                if not start_date or role['updated_at'] >= start_date
+            ]
+            return roles_after_start_date, cursor
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
-
 
     @backoff.on_exception(
         backoff.expo,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -514,6 +514,12 @@ class TestClient():
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
 
+    def get_first_page_and_cursor(self, stream, start_date): # pylint: disable=too-many-return-statements
+        if stream == 'refunds':
+            return next(self.get_refunds(start_date, None))
+        else:
+            raise NotImplementedError("Not implemented for stream {}".format(stream))
+
 
     @backoff.on_exception(
         backoff.expo,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -514,9 +514,11 @@ class TestClient():
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
 
-    def get_first_page_and_cursor(self, stream, start_date): # pylint: disable=too-many-return-statements
+    def get_first_page_and_cursor(self, stream, start_date):
         if stream == 'refunds':
             return next(self.get_refunds(start_date, None))
+        elif stream == 'inventories':
+            return next(self.get_inventories(start_date, None))
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -270,7 +270,7 @@ class TestClient():
             body,
             'counts')
 
-    def get_shifts(self):
+    def get_shifts(self, bookmarked_cursor):
         body = {
             "query": {
                 "sort": {
@@ -279,6 +279,9 @@ class TestClient():
                 }
             }
         }
+
+        if bookmarked_cursor:
+            body['cursor'] = bookmarked_cursor
 
         yield from self._get_v2_objects(
             'shifts',
@@ -503,7 +506,7 @@ class TestClient():
             return [obj for page, _ in self.get_roles(None) for obj in page
                     if not start_date or obj['updated_at'] >= start_date]
         elif stream == 'shifts':
-            return [obj for page, _ in self.get_shifts() for obj in page
+            return [obj for page, _ in self.get_shifts(None) for obj in page
                     if obj['updated_at'] >= start_date]
         elif stream == 'settlements':
             return [obj for page, _ in self.get_settlements_pages(start_date, None) for obj in page]
@@ -535,6 +538,13 @@ class TestClient():
                 if not start_date or role['updated_at'] >= start_date
             ]
             return roles_after_start_date, cursor
+        elif stream == 'shifts':
+            shifts, cursor = next(self.get_shifts(None))
+            shifts_after_start_date = [
+                shift for shift in shifts
+                if not start_date or shift['updated_at'] >= start_date
+            ]
+            return shifts_after_start_date, cursor
         else:
             raise NotImplementedError("Not implemented for stream {}".format(stream))
 
@@ -957,10 +967,10 @@ class TestClient():
 
     def _create_item(self, start_date, num_records=1):
         mod_lists = self.get_all('modifier_lists', start_date)
-        if mod_lists:
-            mod_list_id = random.choice(mod_lists).get('id')
-        else:
-            mod_list_id = self.create_modifier_list(num_records).body.get('objects').get('id')
+        if not mod_lists:
+            mod_lists = self.create_modifier_list(1).body.get('objects')
+
+        mod_list_id = random.choice(mod_lists).get('id')
 
         item_ids = [self.make_id('item') for n in range(num_records)]
         objects = [{'id': item_id,

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -10,28 +10,10 @@ from test_client import TestClient
 LOGGER = singer.get_logger()
 
 
+
 class TestSquarePagination(TestSquareBaseParent.TestSquareBase):
     """Test that we are paginating for streams when exceeding the API record limit of a single query"""
 
-    DEFAULT_BATCH_LIMIT = 1000
-    API_LIMIT = {
-        'items': DEFAULT_BATCH_LIMIT,
-        'inventories': DEFAULT_BATCH_LIMIT,
-        'categories': DEFAULT_BATCH_LIMIT,
-        'discounts': DEFAULT_BATCH_LIMIT,
-        'taxes': DEFAULT_BATCH_LIMIT,
-        'cash_drawer_shifts': DEFAULT_BATCH_LIMIT,
-        'employees': 50,
-        'locations': None, # Api does not accept a cursor and documents no limit, see https://developer.squareup.com/reference/square/locations/list-locations
-        'roles': 100,
-        'refunds': 100,
-        'payments': 100,
-        'customers': 100,
-        'modifier_lists': DEFAULT_BATCH_LIMIT,
-        'orders': 500,
-        'shifts': 200,
-        'settlements': 200,
-    }
 
     @staticmethod
     def name():


### PR DESCRIPTION
# Description of change
-Remove bookmark cursor from incremental streams and test bookmark cursor for every stream using it
-If we get any exception (after retrying) while querying for a stream we clear the pagination bookmark and re-raise the exception (so we still see a hard failure on that tap run and it should be able to recover next time). This is to avoid cursor timing out which is another bug that at least one of the support tickets had. There was no great way to distinguish a cursor timing out or a bad cursor value or other bad requests. It lets the stream be interruptible, but avoids letting customers get into a non-recoverable state.

Streams which we removed the bookmark cursor from because they bookmark already with a replication key:
1. customers
1. orders
1. All catalog streams: items, categories, discounts, taxes, modifier lists 

Streams we added back / fixed the cursor functionality to that were missing it / not using it correctly:
1. shifts
1. employees
1. roles

Explanation of new test_bookmarks_cursor test:

1. In the test client call the same exact query that the tap uses, grab first page of values and the cursor value, don’t call the query again with that cursor
1. Shove that cursor value into the state / bookmarked cursor value before starting the tap.
1. Start the tap, expecting it to use that bookmarked cursor value.
1. Compare the pks of records from the tap against all the records (using get_all which iterates through all pages) and subtracting the first page value pks
 
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
