### PR TITLE
run 3rd sync if customers stream needs it in bookmarks test

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -23,6 +23,7 @@ class DataType(Enum):
     STATIC = 2
 
 
+# TODO refactor methods so that it is clear which streams fall into which categories for testing
 class TestSquareBaseParent:
     # Creating TestSquareBase inside a parent class to avoid
     # unittest trying to run methods in base class starting with 'test'

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -384,7 +384,7 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
                                    'We are running another sync to attempt to catch them.', stream)
 
                     # Run another sync since square can't keep up
-                    third_sync_record_count = self.run_sync(conn_id)
+                    _ = self.run_sync(conn_id)
 
                     # Get the set of records from a thrid sync and apply
                     third_sync_records = runner.get_records_from_target_output()

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -380,8 +380,7 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
                     #       and we were unable to produce a scenario in which a subsequent sync failed to pick
                     #       up the create and update after failing to catch them in the 2nd sync.
 
-                    LOGGER.warning('Second sync missed %s records that were just created and updated. ' + \
-                                   'We are running another sync to attempt to catch them.', stream)
+                    LOGGER.warning('Second sync missed %s records that were just created and updated.', stream)
 
                     # Run another sync since square can't keep up
                     _ = self.run_sync(conn_id)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -373,8 +373,23 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
                                      "\tState: {}\n".format(second_sync_state) + \
                                      "\tBookmark: {}".format(second_state))
 
-                if stream == 'customers': # BUG https://stitchdata.atlassian.net/browse/SRCE-4639
-                    continue  # WORKAROUND
+                if stream == 'customers' and len(second_sync_data) == 0: # BUG https://stitchdata.atlassian.net/browse/SRCE-4639
+                    # NOTE: Square sometimes lags on the customers stream, so we'll give them one more shot
+                    #       before we say this stream fails in catching the create and update. This was tested
+                    #       manually while syncing all streams and while sycning only the customers stream
+                    #       and we were unable to produce a scenario in which a subsequent sync failed to pick
+                    #       up the create and update after failing to catch them in the 2nd sync.
+
+                    LOGGER.warning('Second sync missed %s records that were just created and updated. ' + \
+                                   'We are running another sync to attempt to catch them.', stream)
+
+                    # Run another sync since square can't keep up
+                    third_sync_record_count = self.run_sync(conn_id)
+
+                    # Get the set of records from a thrid sync and apply
+                    third_sync_records = runner.get_records_from_target_output()
+                    second_sync_data = [record.get("data") for record
+                                        in third_sync_records.get(stream, {}).get("messages", [])]
 
                 # TESTING APPLICABLE TO ALL STREAMS
 


### PR DESCRIPTION
# Description of change
The customers stream is proving to be inconsistent in the amount of time it takes square to return newly created and updated objects. This implements a workaround for that stream in the bookmarks test, if the 2nd sync does not catch the records we expected we run a 3rd sync and compare against those records instead.
# Manual QA steps
 - Ran through an adjusted bookmarks test attempting to produce a series of syncs which did not catch the updated and created records. 
 - Tested this by syncing all streams  and by syncing only the customers streams. Only performed creates and updates  for the customers stream in these tests.
 
# Risks
 - None, this is an addition to the bookmarks test and can only add coverage to the customers stream. 
 
# Rollback steps
 - revert this branch
