### PR TITLE
Bump version to 1.2.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.2.0](https://github.com/singer-io/tap-square/tree/v1.2.0) (2020-12-31)
+
+[Full Changelog](https://github.com/singer-io/tap-square/compare/v1.1.0...v1.2.0)
+
+**Merged pull requests:**
+
+- run 3rd sync if customers stream needs it in bookmarks test [\#93](https://github.com/singer-io/tap-square/pull/93) ([kspeer825](https://github.com/kspeer825))
+- Remove bookmark cursor from incremental streams and test bookmark cursor for every stream using it [\#92](https://github.com/singer-io/tap-square/pull/92) ([asaf-erlich](https://github.com/asaf-erlich))
+- Refactor sync code into invidual stream classes [\#91](https://github.com/singer-io/tap-square/pull/91) ([asaf-erlich](https://github.com/asaf-erlich))
+- stabilize bookmarks by removing customers from all assertions [\#90](https://github.com/singer-io/tap-square/pull/90) ([kspeer825](https://github.com/kspeer825))
+- change cron time [\#89](https://github.com/singer-io/tap-square/pull/89) ([kspeer825](https://github.com/kspeer825))
+
 ## [v1.1.0](https://github.com/singer-io/tap-square/tree/v1.0.2) (2020-12-10)
 
 * Fix customers stream to use date windowing to query [\#87](https://github.com/singer-io/tap-square/pull/84) ([cosimon](https://github.com/cosimon))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-square',
-      version='1.1.0',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Square API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Changelog generated with https://github.com/github-changelog-generator/github-changelog-generator , but I figured out how to only do it for a future release since the previous tag and output it to a separate file so it's easy to avoid overriding the existing changelog. I'll create a PR to document this.

TLDR:
```
docker run -it --rm -v "$(pwd)":/usr/local/src/your-app docker.io/ferrarimarco/github-changelog-generator --user singer-io --project tap-square --token $CHANGELOG_GITHUB_TOKEN --output temp-new-changelog --since-tag v1.1.0 --future-release v1.2.0
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
