### PR TITLE
run pylint with tap-tester not tap venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
       - run:
           name: 'pylint tests'
           command: |
-            source /usr/local/share/virtualenvs/tap-square/bin/activate
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            pip install pylint
             pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy'
       - run:
           name: 'JSON Validator'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pylint
-            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error'
+            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error,use-a-generator'
       - run:
           name: 'JSON Validator'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pylint
-            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error,use-a-generator'
+            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error,use-a-generator,consider-using-generator'
       - run:
           name: 'JSON Validator'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |
             python3 -m venv /usr/local/share/virtualenvs/tap-square
             source /usr/local/share/virtualenvs/tap-square/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U pip setuptools
             pip install .[dev]
       - run:
           name: 'pylint tap'
@@ -29,12 +29,12 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pylint
-            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy'
+            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error'
       - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-square/lib/python3.5/site-packages/tap_square/schemas/*.json
+            stitch-validate-json tap_square/schemas/*.json
 
   all-integ-tests-running-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pylint
-            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error,use-a-generator,consider-using-generator'
+            pylint tests -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,logging-not-lazy,import-error,use-a-generator,consider-using-generator,raise-missing-from'
       - run:
           name: 'JSON Validator'
           command: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[MASTER]
-init-hook='import sys; sys.path.append("/opt/code/tap-tester/"); sys.path.append("/code/tap-tester/");'
-
-[MESSAGES CONTROL]
-disable=broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods,missing-docstring

--- a/tests/base.py
+++ b/tests/base.py
@@ -693,7 +693,7 @@ class TestSquareBaseParent:
 
         def assertDictEqualWithOffKeys(self, expected_record, sync_record, off_keys=frozenset()):
             """
-            This method is currenlty being used to enable us to compare records for streams which 
+            This method is currenlty being used to enable us to compare records for streams which
             have known discrepancies.
 
             Currently those known discrepancies include:

--- a/tests/base.py
+++ b/tests/base.py
@@ -692,15 +692,38 @@ class TestSquareBaseParent:
                 self.assertDictEqual(expected_record, sync_record)
 
         def assertDictEqualWithOffKeys(self, expected_record, sync_record, off_keys=frozenset()):
-            # self.assertParentKeysEqual(expected_record, sync_record)
+            """
+            This method is currenlty being used to enable us to compare records for streams which 
+            have known discrepancies.
+
+            Currently those known discrepancies include:
+             -  https://stitchdata.atlassian.net/browse/SRCE-4975
+             -  https://stitchdata.atlassian.net/browse/SRCE-5143
+            """
+
             expected_record_copy = deepcopy(expected_record)
             sync_record_copy = deepcopy(sync_record)
 
-            # Square api workflow updates these values so they're a few seconds different between
-            # the time the record is created and the tap syncs, but other fields are the same
             for off_key in off_keys:
                 if sync_record_copy.get(off_key):
                     sync_record_copy.pop(off_key)
                 if expected_record_copy.get(off_key):
                     expected_record_copy.pop(off_key)
             self.assertDictEqual(expected_record_copy, sync_record_copy)
+
+        def assertParentKeysEqualWithOffKeys(self, expected_record, sync_record, off_keys=frozenset()):
+            """
+            We cannot always gaurrantee that the schema is up-to-date with the latest fields.
+            So to get around the test expectations sometimes being ahead of tap maintenance
+            we are including this assertion for streams that are currently failing the standard
+            assertRecordsEqual.
+            """
+            expected_record_copy = deepcopy(expected_record)
+            sync_record_copy = deepcopy(sync_record)
+
+            for off_key in off_keys:
+                if sync_record_copy.get(off_key):
+                    sync_record_copy.pop(off_key)
+                if expected_record_copy.get(off_key):
+                    expected_record_copy.pop(off_key)
+            self.assertParentKeysEqual(expected_record_copy, sync_record_copy)

--- a/tests/base.py
+++ b/tests/base.py
@@ -692,13 +692,15 @@ class TestSquareBaseParent:
                 self.assertDictEqual(expected_record, sync_record)
 
         def assertDictEqualWithOffKeys(self, expected_record, sync_record, off_keys=frozenset()):
-            self.assertParentKeysEqual(expected_record, sync_record)
+            # self.assertParentKeysEqual(expected_record, sync_record)
             expected_record_copy = deepcopy(expected_record)
             sync_record_copy = deepcopy(sync_record)
 
             # Square api workflow updates these values so they're a few seconds different between
             # the time the record is created and the tap syncs, but other fields are the same
             for off_key in off_keys:
-                sync_record_copy.pop(off_key)
-                expected_record_copy.pop(off_key)
+                if sync_record_copy.get(off_key):
+                    sync_record_copy.pop(off_key)
+                if expected_record_copy.get(off_key):
+                    expected_record_copy.pop(off_key)
             self.assertDictEqual(expected_record_copy, sync_record_copy)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -161,16 +161,31 @@ class TestSquareAllFields(TestSquareBaseParent.TestSquareBase):
                 for record in expected_records.get(stream):
                     expected_keys.update(record.keys())
 
-                # Verify schema covers all fields
-                schema_keys = set(self.expected_schema_keys(stream))
-                self.assertEqual(
-                    set(), expected_keys.difference(schema_keys),
-                    msg="\nFields missing from schema: {}\n".format(expected_keys.difference(schema_keys))
-                )
+                MISSING_FROM_EXPECTATIONS = { # this is acceptable, we can't generate test data for EVERYTHING
+                    'modifier_lists': {'absent_at_location_ids'},
+                    'items': {'present_at_location_ids', 'absent_at_location_ids'},
+                    'categories': {'absent_at_location_ids'},
+                    'orders': {
+                        'amount_money', 'item_data', 'delayed_until', 'order_id', 'reason', 'processing_fee',
+                        'tax_data','status','is_deleted','discount_data','delay_duration','source_type',
+                        'receipt_number','receipt_url','card_details','delay_action','type','category_data',
+                        'payment_id','refund_ids','note','present_at_all_locations', 'refunded_money'
+                    },
+                    'discounts': {'absent_at_location_ids'},
+                    'taxes': {'absent_at_location_ids'},
+                    'customers': {'birthday'},
+                    'payments': {'customer_id', 'reference_id'},
+                    'locations': {'facebook_url'},
+                    'employees': {'is_owner'},
+                }
+                # BUG_2 | https://stitchdata.atlassian.net/browse/SRCE-5143
+                MISSING_FROM_SCHEMA = {'payments': {'capabilities', 'version_token', 'approved_money'}}
 
-                # not a test, just logging the fields that are included in the schema but not in the expectations
-                if schema_keys.difference(expected_keys):
-                    print("WARNING Fields missing from expectations: {}".format(schema_keys.difference(expected_keys)))
+                # Verify schema matches expectations
+                schema_keys = set(self.expected_schema_keys(stream))
+                schema_keys.update(MISSING_FROM_SCHEMA.get(stream, set()))  # REMOVE W/ BUG_2 FIX
+                expected_keys.update(MISSING_FROM_EXPECTATIONS.get(stream, set()))
+                self.assertSetEqual(expected_keys, schema_keys)
 
                 # Verify that all fields sent to the target fall into the expected schema
                 for actual_keys in record_messages_keys:
@@ -191,11 +206,13 @@ class TestSquareAllFields(TestSquareBaseParent.TestSquareBase):
                     actual_record = actual_pks_to_record_dict.get(pks_tuple)
 
                     # Test Workaround Start ##############################
-                    # BUG | https://stitchdata.atlassian.net/browse/SRCE-4975
+                    # BUG_1 | https://stitchdata.atlassian.net/browse/SRCE-4975
                     if stream == 'payments':
-
+                        # NB | In order to compare
+                        PARENT_FIELD_MISSING_SUBFIELDS = {'card_details'} # BUG_1
+                        PARENT_FIELD_MISSING_SUBFIELDS.update(MISSING_FROM_SCHEMA[stream]) # BUG_2
                         self.assertDictEqualWithOffKeys(
-                            expected_record, actual_record, {'card_details',}
+                            expected_record, actual_record, PARENT_FIELD_MISSING_SUBFIELDS
                         )
 
                     else:  # Test Workaround End ##############################

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -476,11 +476,11 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
 
                         off_keys = MISSING_FROM_SCHEMA[stream] # BUG_2
                         self.assertParentKeysEqualWithOffKeys(
-                            expected_record, actual_record, off_keys
+                            created_record, sync_record, off_keys
                         )
                         off_keys = PARENT_FIELD_MISSING_SUBFIELDS[stream] | MISSING_FROM_SCHEMA[stream] # BUG_1 | # BUG_2
                         self.assertDictEqualWithOffKeys(
-                            updated_record, sync_record, off_keys
+                            created_record, sync_record, off_keys
                         )  # Test Workaround End ##############################
 
                     else:
@@ -505,7 +505,7 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
 
                             off_keys = MISSING_FROM_SCHEMA[stream] # BUG_2
                             self.assertParentKeysEqualWithOffKeys(
-                                expected_record, actual_record, off_keys
+                                updated_record, sync_record, off_keys
                             )
                             off_keys = PARENT_FIELD_MISSING_SUBFIELDS[stream] | MISSING_FROM_SCHEMA[stream] # BUG_1 | # BUG_2
                             self.assertDictEqualWithOffKeys(

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -485,11 +485,20 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
                                              msg="A duplicate record was found in the sync for {}\nRECORDS: {}.".format(stream, sync_records))
 
                         sync_record = sync_records[0]
+
+                        # BUG_2 | https://stitchdata.atlassian.net/browse/SRCE-5143
+                        MISSING_FROM_SCHEMA = {'payments': {'capabilities', 'version_token', 'approved_money'}}
+
                         # Test Workaround Start ##############################
-                        # BUG | https://stitchdata.atlassian.net/browse/SRCE-4975
+                        # BUG_1 | https://stitchdata.atlassian.net/browse/SRCE-4975
                         if stream == 'payments':
+
+                            PARENT_FIELD_MISSING_SUBFIELDS = {'card_details'} # BUG_1
+                            PARENT_FIELD_MISSING_SUBFIELDS.update(MISSING_FROM_SCHEMA[stream]) # BUG_2
+
                             self.assertDictEqualWithOffKeys(
-                                updated_record, sync_record, {'card_details',}
+                                updated_record, sync_record, PARENT_FIELD_MISSING_SUBFIELDS
                             )  # Test Workaround End ##############################
+
                         else:
                             self.assertRecordsEqual(stream, updated_record, sync_record)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -323,6 +323,14 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
 
         second_sync_state = menagerie.get_state(conn_id)
 
+
+        # BUG_1 | https://stitchdata.atlassian.net/browse/SRCE-4975
+        PARENT_FIELD_MISSING_SUBFIELDS = {'payments': {'card_details'}}
+
+        # BUG_2 | https://stitchdata.atlassian.net/browse/SRCE-5143
+        MISSING_FROM_SCHEMA = {'payments': {'capabilities', 'version_token', 'approved_money'}}
+
+
         # Loop first_sync_records and compare against second_sync_records
         for stream in testable_streams:
             with self.subTest(stream=stream):
@@ -464,11 +472,17 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
                                      msg="A duplicate record was found in the sync for {}\nRECORD: {}.".format(stream, sync_records))
                     sync_record = sync_records[0]
                     # Test Workaround Start ##############################
-                    # BUG | https://stitchdata.atlassian.net/browse/SRCE-4975
                     if stream == 'payments':
+
+                        off_keys = MISSING_FROM_SCHEMA[stream] # BUG_2
+                        self.assertParentKeysEqualWithOffKeys(
+                            expected_record, actual_record, off_keys
+                        )
+                        off_keys = PARENT_FIELD_MISSING_SUBFIELDS[stream] | MISSING_FROM_SCHEMA[stream] # BUG_1 | # BUG_2
                         self.assertDictEqualWithOffKeys(
-                            created_record, sync_record, {'card_details',}
+                            updated_record, sync_record, off_keys
                         )  # Test Workaround End ##############################
+
                     else:
                         self.assertRecordsEqual(stream, created_record, sync_record)
 
@@ -486,18 +500,16 @@ class TestSquareIncrementalReplication(TestSquareBaseParent.TestSquareBase):
 
                         sync_record = sync_records[0]
 
-                        # BUG_2 | https://stitchdata.atlassian.net/browse/SRCE-5143
-                        MISSING_FROM_SCHEMA = {'payments': {'capabilities', 'version_token', 'approved_money'}}
-
                         # Test Workaround Start ##############################
-                        # BUG_1 | https://stitchdata.atlassian.net/browse/SRCE-4975
                         if stream == 'payments':
 
-                            PARENT_FIELD_MISSING_SUBFIELDS = {'card_details'} # BUG_1
-                            PARENT_FIELD_MISSING_SUBFIELDS.update(MISSING_FROM_SCHEMA[stream]) # BUG_2
-
+                            off_keys = MISSING_FROM_SCHEMA[stream] # BUG_2
+                            self.assertParentKeysEqualWithOffKeys(
+                                expected_record, actual_record, off_keys
+                            )
+                            off_keys = PARENT_FIELD_MISSING_SUBFIELDS[stream] | MISSING_FROM_SCHEMA[stream] # BUG_1 | # BUG_2
                             self.assertDictEqualWithOffKeys(
-                                updated_record, sync_record, PARENT_FIELD_MISSING_SUBFIELDS
+                                updated_record, sync_record, off_keys
                             )  # Test Workaround End ##############################
 
                         else:


### PR DESCRIPTION
# Description of change
For pylint ran against the tests, we should use the tap-tester venv.

Also new fields were added by square to the payments stream.  A backlog ticket was created and workarounds were implemented in the test for those fields.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
