### PR TITLE
bump singer to 5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.3.1](https://github.com/singer-io/tap-square/tree/v1.3.1) (2021-03-23)
+
+* Bumped singer-python to version 5.12.1 [\#103](https://github.com/singer-io/tap-square/pull/103) ([zachharris1](https://github.com/zachharris1))
+
+[Full Changelog](https://github.com/singer-io/tap-square/compare/v1.3.0...v1.3.1)
+
 ## [v1.3.0](https://github.com/singer-io/tap-square/tree/v1.w.0) (2021-01-21)
 
 [Full Changelog](https://github.com/singer-io/tap-square/compare/v1.2.0...v1.3.0)

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup
 
 setup(name='tap-square',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting data from the Square API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_square'],
       install_requires=[
-          'singer-python==5.9.0',
+          'singer-python==5.12.1',
           'squareup==5.3.0.20200528',
           'backoff==1.8.0',
           'methodtools==0.4.2',

--- a/tap_square/schemas/locations.json
+++ b/tap_square/schemas/locations.json
@@ -33,14 +33,14 @@
             "null",
             "string"
           ],
-          "format": "singer-decimal"
+          "format": "singer.decimal"
         },
         "longitude": {
           "type": [
             "null",
             "string"
           ],
-          "format": "singer-decimal"
+          "format": "singer.decimal"
         }
       }
     },


### PR DESCRIPTION
# Description of change
bump singer-python to 5.12.1

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
