### PR TITLE
version bump to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [v1.3.1](https://github.com/singer-io/tap-square/tree/v1.w.0) (2021-06-10)
+
+[Full Changelog](https://github.com/singer-io/tap-square/compare/v1.3.0...v1.3.1)
+
+* Removes `item_data` object from orders.json [#100](https://github.com/singer-io/tap-square/pull/100)
 
 ## [v1.3.0](https://github.com/singer-io/tap-square/tree/v1.w.0) (2021-01-21)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-square',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting data from the Square API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
## [v1.3.1](https://github.com/singer-io/tap-square/tree/v1.w.0) (2021-06-10)

[Full Changelog](https://github.com/singer-io/tap-square/compare/v1.3.0...v1.3.1)

* Removes `item_data` object from orders.json [#100](https://github.com/singer-io/tap-square/pull/100)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
